### PR TITLE
Add Trailing Slash to Path

### DIFF
--- a/lib/i18n.module.ts
+++ b/lib/i18n.module.ts
@@ -14,6 +14,7 @@ import {
 } from './interfaces/i18n-options.interface';
 import { ValueProvider } from '@nestjs/common/interfaces';
 import { parseTranslations } from './utils/parse';
+import * as path from 'path';
 
 const logger = new Logger('I18nService');
 
@@ -21,6 +22,8 @@ const logger = new Logger('I18nService');
 @Module({})
 export class I18nModule {
   static forRoot(options: I18nOptions): DynamicModule {
+    options.path = path.normalize(options.path + path.sep);
+
     const i18nOptions: ValueProvider = {
       provide: I18N_OPTIONS,
       useValue: options,

--- a/lib/i18n.module.ts
+++ b/lib/i18n.module.ts
@@ -14,7 +14,6 @@ import {
 } from './interfaces/i18n-options.interface';
 import { ValueProvider } from '@nestjs/common/interfaces';
 import { parseTranslations } from './utils/parse';
-import * as path from 'path';
 
 const logger = new Logger('I18nService');
 
@@ -22,8 +21,6 @@ const logger = new Logger('I18nService');
 @Module({})
 export class I18nModule {
   static forRoot(options: I18nOptions): DynamicModule {
-    options.path = path.normalize(options.path + path.sep);
-
     const i18nOptions: ValueProvider = {
       provide: I18N_OPTIONS,
       useValue: options,

--- a/lib/utils/parse.ts
+++ b/lib/utils/parse.ts
@@ -15,6 +15,8 @@ export async function parseTranslations(
   i18nPath: string,
 ): Promise<I18nTranslation> {
   return new Promise<I18nTranslation>((resolve, reject) => {
+    i18nPath = path.normalize(i18nPath + path.sep);
+
     const translations: I18nTranslation = {};
 
     if (!fs.existsSync(i18nPath)) {

--- a/tests/i18n-async.spec.ts
+++ b/tests/i18n-async.spec.ts
@@ -25,4 +25,39 @@ describe('i18n module', () => {
   it('i18n service should be defined', async () => {
     expect(i18nService).toBeTruthy();
   });
+
+  it('i18n service should return correct translation', async () => {
+    expect(i18nService.translate('en', 'HELLO')).toBe('Hello');
+    expect(i18nService.translate('nl', 'HELLO')).toBe('Hallo');
+  });
+});
+
+describe('i18n module without trailing slash in path', () => {
+  let i18nService: I18nService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRootAsync({
+          useFactory: () => {
+            return {
+              path: path.join(__dirname, '/i18n'),
+              fallbackLanguage: 'en',
+            };
+          },
+        }),
+      ],
+    }).compile();
+
+    i18nService = module.get(I18nService);
+  });
+
+  it('i18n service should be defined', async () => {
+    expect(i18nService).toBeTruthy();
+  });
+
+  it('i18n service should return correct translation', async () => {
+    expect(i18nService.translate('en', 'HELLO')).toBe('Hello');
+    expect(i18nService.translate('nl', 'HELLO')).toBe('Hallo');
+  });
 });

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -64,3 +64,29 @@ describe('i18n module', () => {
     expect(i18nService.translate('nl', 'COMPANY')).toBe('Wim');
   });
 });
+
+describe('i18n module without trailing slash in path', () => {
+  let i18nService: I18nService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRoot({
+          path: path.join(__dirname, '/i18n'),
+          fallbackLanguage: 'en',
+        }),
+      ],
+    }).compile();
+
+    i18nService = module.get(I18nService);
+  });
+
+  it('i18n service should be defined', async () => {
+    expect(i18nService).toBeTruthy();
+  });
+
+  it('i18n service should return correct translation', async () => {
+    expect(i18nService.translate('en', 'HELLO')).toBe('Hello');
+    expect(i18nService.translate('nl', 'HELLO')).toBe('Hallo');
+  });
+});


### PR DESCRIPTION
This PR adds a trailing slash to the `parse()` method when loading the translations. In the current state, the translations cannot be loaded if you pass a path **without** trailing slashes.