### PR TITLE
File Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,17 @@ import { I18nModule } from 'nestjs-i18n';
 
 @Module({
   imports: [
-    I18nModule.forRoot({path: path.join(__dirname, '/i18n/'), fallbackLanguage: 'en'}),
+    I18nModule.forRoot({
+      path: path.join(__dirname, '/i18n'), 
+      filePattern: '*.json',
+      fallbackLanguage: 'en',
+    }),
   ],
   controllers: []
 })
 export class AppModule {}
-
 ```
+
 #### using forRootAsync
 ```
 import { Module } from '@nestjs/common';
@@ -71,17 +75,19 @@ import { I18nModule } from 'nestjs-i18n';
 @Module({
   imports: [
     I18nModule.forRootAsync({ 
-        useFactory: (config: ConfigurationService) => (
-            { path: configService.i18nPath, fallbackLanguage: 'es' }
-        ),
+        useFactory: (config: ConfigurationService) => ({ 
+          path: configService.i18nPath, 
+          fallbackLanguage: configService.fallbackLanguage, // e.g., 'en'
+          filePattern: configService.i18nFilePattern, // e.g., '*.i18n.json'
+        }),
         inject: [ConfigurationService] 
     }),
   ],
   controllers: []
 })
 export class AppModule {}
-
 ```
+
 ### Using translation service
 ```
 @Controller()

--- a/lib/interfaces/i18n-options.interface.ts
+++ b/lib/interfaces/i18n-options.interface.ts
@@ -5,6 +5,7 @@ export type I18nLoadingType = 'BY_LANGUAGE' | 'BY_DOMAIN';
 
 export interface I18nOptions {
   path: string;
+  filePattern?: string;
   fallbackLanguage?: string;
 }
 

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -63,6 +63,10 @@ describe('i18n module', () => {
     expect(i18nService.translate('en', 'COMPANY')).toBe('Toon');
     expect(i18nService.translate('nl', 'COMPANY')).toBe('Wim');
   });
+
+  it('i18n service should not load the custom file', async () => {
+    expect(i18nService.translate('en', 'custom')).toBeUndefined();
+  });
 });
 
 describe('i18n module without trailing slash in path', () => {
@@ -88,5 +92,65 @@ describe('i18n module without trailing slash in path', () => {
   it('i18n service should return correct translation', async () => {
     expect(i18nService.translate('en', 'HELLO')).toBe('Hello');
     expect(i18nService.translate('nl', 'HELLO')).toBe('Hallo');
+  });
+});
+
+describe('i18n module loads custom files', () => {
+  let i18nService: I18nService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRoot({
+          path: path.join(__dirname, '/i18n/'),
+          filePattern: '*.custom',
+          fallbackLanguage: 'en',
+        }),
+      ],
+    }).compile();
+
+    i18nService = module.get(I18nService);
+  });
+
+  it('i18n service should be defined', async () => {
+    expect(i18nService).toBeTruthy();
+  });
+
+  it('i18n service should return correct translation', async () => {
+    expect(i18nService.translate('en', 'custom')).toBe('my custom text');
+  });
+
+  it('i18n service should not load the custom file', async () => {
+    expect(i18nService.translate('en', 'HELLO')).toBeUndefined();
+  });
+});
+
+describe('i18n module loads custom files with wrong file pattern', () => {
+  let i18nService: I18nService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRoot({
+          path: path.join(__dirname, '/i18n/'),
+          filePattern: 'custom',
+          fallbackLanguage: 'en',
+        }),
+      ],
+    }).compile();
+
+    i18nService = module.get(I18nService);
+  });
+
+  it('i18n service should be defined', async () => {
+    expect(i18nService).toBeTruthy();
+  });
+
+  it('i18n service should return correct translation', async () => {
+    expect(i18nService.translate('en', 'custom')).toBe('my custom text');
+  });
+
+  it('i18n service should not load the custom file', async () => {
+    expect(i18nService.translate('en', 'HELLO')).toBeUndefined();
   });
 });

--- a/tests/i18n/en/test.custom
+++ b/tests/i18n/en/test.custom
@@ -1,0 +1,3 @@
+{
+  "custom": "my custom text"
+}


### PR DESCRIPTION
This PR adds the feature to define a file-pattern (i.e., the currently hard-coded `*.json`) when loading translation files.

In particular, it does:
- add "default i18noptions"
- add possibility to change the file-pattern for loading files
- added tests
- update readme file

feedback is appreciated