### PR TITLE
remove: pathPattern parameter from example options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ import { I18nModule } from 'nestjs-i18n';
         useFactory: (config: ConfigurationService) => ({ 
           path: configService.i18nPath, 
           fallbackLanguage: configService.fallbackLanguage, // e.g., 'en'
-          filePattern: configService.i18nFilePattern, // e.g., '*.i18n.json'
         }),
         inject: [ConfigurationService] 
     }),

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ import { I18nModule } from 'nestjs-i18n';
   imports: [
     I18nModule.forRoot({
       path: path.join(__dirname, '/i18n'), 
-      filePattern: '*.json',
       fallbackLanguage: 'en',
     }),
   ],


### PR DESCRIPTION
Hey! Sweet package you got here 😀.

Just creating this PR to update the 'getting started example'. It doesn't look like the `filePattern` parameter is supported anymore.