### PR TITLE
feat: append forward slash to i18npath

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ import { I18nModule } from 'nestjs-i18n';
         useFactory: (config: ConfigurationService) => ({ 
           path: configService.i18nPath, 
           fallbackLanguage: configService.fallbackLanguage, // e.g., 'en'
-          filePattern: configService.i18nFilePattern, // e.g., '*.i18n.json'
         }),
         inject: [ConfigurationService] 
     }),

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ import { I18nModule } from 'nestjs-i18n';
   imports: [
     I18nModule.forRoot({
       path: path.join(__dirname, '/i18n'), 
+      filePattern: '*.json',
       fallbackLanguage: 'en',
     }),
   ],
@@ -77,6 +78,7 @@ import { I18nModule } from 'nestjs-i18n';
         useFactory: (config: ConfigurationService) => ({ 
           path: configService.i18nPath, 
           fallbackLanguage: configService.fallbackLanguage, // e.g., 'en'
+          filePattern: configService.i18nFilePattern, // e.g., '*.i18n.json'
         }),
         inject: [ConfigurationService] 
     }),

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ import { I18nModule } from 'nestjs-i18n';
   imports: [
     I18nModule.forRoot({
       path: path.join(__dirname, '/i18n'), 
-      filePattern: '*.json',
       fallbackLanguage: 'en',
     }),
   ],

--- a/lib/utils/parse.ts
+++ b/lib/utils/parse.ts
@@ -29,7 +29,7 @@ export async function parseTranslations(
     );
 
     glob(
-      i18nPath + '**/' + options.filePattern,
+      i18nPath + '/**/' + options.filePattern,
       (err: Error, files: string[]) => {
         if (err) {
           return reject(err);


### PR DESCRIPTION
Adding a forward slash to the i18npath will free the user from having to provide a path with a trailing forward slash.

[The example in the readme does not have a trailing forward slash.](https://github.com/ToonvanStrijp/nestjs-i18n#translation-module)