### PR TITLE
Use fallback language if a string is requested for a non supported language

### DIFF
--- a/lib/services/i18n.service.ts
+++ b/lib/services/i18n.service.ts
@@ -22,20 +22,14 @@ export class I18nService {
     key: string,
     args?: Array<{ [k: string]: any } | string> | { [k: string]: any },
   ) {
-    let translation = this.translations[lang][key];
+    let translationByLanguage = this.translations[lang];
+    if (translationByLanguage === undefined || translationByLanguage === null) {
+      return this.defaultToFallbackLanguage(lang, key, args);
+    }
 
+    let translation = translationByLanguage[key];
     if (translation === undefined || translation === null) {
-      const message = `translation "${key}" in "${lang}" doesn't exist.`;
-      this.logger.error(message);
-      if (
-        (this.i18nOptions.fallbackLanguage !== null ||
-          this.i18nOptions.fallbackLanguage !== undefined) &&
-        lang !== this.i18nOptions.fallbackLanguage
-      ) {
-        return this.translate(this.i18nOptions.fallbackLanguage, key, args);
-      } else {
-        return undefined;
-      }
+      return this.defaultToFallbackLanguage(lang, key, args);
     }
     if (args || (args instanceof Array && args.length > 0)) {
       translation = format(
@@ -44,5 +38,23 @@ export class I18nService {
       );
     }
     return translation;
+  }
+
+  private defaultToFallbackLanguage(
+    lang: string,
+    key: string,
+    args?: Array<{ [k: string]: any } | string> | { [k: string]: any },
+  ) {
+    const message = `translation "${key}" in "${lang}" doesn't exist.`;
+    this.logger.error(message);
+    if (
+      (this.i18nOptions.fallbackLanguage !== null ||
+        this.i18nOptions.fallbackLanguage !== undefined) &&
+      lang !== this.i18nOptions.fallbackLanguage
+    ) {
+      return this.translate(this.i18nOptions.fallbackLanguage, key, args);
+    } else {
+      return undefined;
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2104,8 +2104,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2126,14 +2125,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2148,20 +2145,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2278,8 +2272,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2291,7 +2284,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2306,7 +2298,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2314,14 +2305,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2340,7 +2329,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2421,8 +2409,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2434,7 +2421,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2520,8 +2506,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2557,7 +2542,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2577,7 +2561,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2621,14 +2604,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -54,6 +54,10 @@ describe('i18n module', () => {
     expect(i18nService.translate('nl', 'ENGLISH')).toBe('English');
   });
 
+  it('i18n service should return fallback translation if language not registed', async () => {
+    expect(i18nService.translate('es', 'ENGLISH')).toBe('English');
+  });
+
   it('i18n service should return global translation in each language', async () => {
     expect(i18nService.translate('en', 'APP_NAME')).toBe('Nest-I18N');
     expect(i18nService.translate('nl', 'APP_NAME')).toBe('Nest-I18N');


### PR DESCRIPTION
This fixes a bug where a user might be requesting a string for a language that is not registered, but there's a fallback option available.

Thank you so much!