### PR TITLE
fix: export header resolver

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,4 +4,5 @@ export * from './services/i18n.service';
 export * from './interfaces/i18n-options.interface';
 export * from './interfaces/i18n-language-resolver.interface';
 export * from './decorators/i18n-lang.decorator';
+export * from './resolvers/header.resolver';
 export * from './resolvers/query.resolver';


### PR DESCRIPTION
This PR exports the (currently missing) `header.resolver`.