### PR TITLE
feat: add missing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ i18n
     └── auth.json
 ```
 
-### Translation file
+### Translation File
 The format for the translation file could look like this:
 ```json
 {
@@ -45,7 +45,7 @@ The format for the translation file could look like this:
 ```
 String formatting is done by: [string-format](https://github.com/davidchambers/string-format)
 
-### Translation module
+### Translation Module
 To use the translation service we first add the module. **The `I18nModule` has an `@Global()` attribute so you should only import it once**.
 ```typescript
 import { Module } from '@nestjs/common';
@@ -65,7 +65,7 @@ import { I18nModule } from 'nestjs-i18n';
 export class AppModule {}
 ```
 
-#### using forRootAsync
+#### Using forRootAsync()
 ```typescript
 import { Module } from '@nestjs/common';
 import * as path from 'path';
@@ -86,7 +86,7 @@ import { I18nModule } from 'nestjs-i18n';
 })
 export class AppModule {}
 ```
-### Language resolvers
+### Language Resolvers
 To make it easier to manage in what language to respond you can make use of resolvers
 
 ```typescript
@@ -106,16 +106,16 @@ To make it easier to manage in what language to respond you can make use of reso
 export class AppModule {}
 ```
 
-There are two build-in resolvers
+Currently, there are two build-in resolvers
 
 | Resolver | Default value |
 | ------------- | ------------- |
 | `QueryResolver`  | `none` |
 | `HeaderResolver`  | `accept-language` |
 
-To implement your own resolver use the `I18nResolver` interface.
+To implement your own resolver (or custom logic) use the `I18nResolver` interface.
 
-### Using translation service and language resolver
+### Using Translation Service and Language Resolver
 ```typescript
 @Controller()
 export class SampleController {
@@ -131,6 +131,21 @@ export class SampleController {
     this.i18n.translate('HELLO_MESSAGE', {lang: lang, args: {id: 1, username: 'Toon'}});
     this.i18n.translate('SETUP.WELCOME', {lang: 'en', args: {id: 1, username: 'Toon'}});
     this.i18n.translate('ARRAY.0', {lang: 'en'});
+  }
+}
+```
+
+### Missing Translations
+
+If you require a translation that is missing, `I18n` will log an error. However, you can also write these missing translations to a new file in order to help translating your application later on.
+
+This behaviour can be controlled via the `saveMissing: boolean` attribute when adding the `I18nModule` to your application. Thereby, `true` describes the following behaviour:
+
+Say, you request the translation `mail.registration.subject` in a `de` language, and this specific key is missing. This will create a `de/mail.missing` file in your `i18n` folder and add the following content:
+```json
+{
+  "registration": {
+    "subject": ""
   }
 }
 ```

--- a/lib/i18n.module.ts
+++ b/lib/i18n.module.ts
@@ -26,7 +26,7 @@ const logger = new Logger('I18nService');
 const defaultOptions: Partial<I18nOptions> = {
   filePattern: '*.json',
   resolvers: [],
-  saveMissings: false,
+  saveMissings: true,
 };
 @Global()
 @Module({})

--- a/lib/i18n.module.ts
+++ b/lib/i18n.module.ts
@@ -26,6 +26,7 @@ const logger = new Logger('I18nService');
 const defaultOptions: Partial<I18nOptions> = {
   filePattern: '*.json',
   resolvers: [],
+  saveMissings: false,
 };
 @Global()
 @Module({})

--- a/lib/interfaces/i18n-options.interface.ts
+++ b/lib/interfaces/i18n-options.interface.ts
@@ -7,6 +7,7 @@ export interface I18nOptions {
   filePattern?: string;
   fallbackLanguage?: string;
   resolvers?: I18nResolver[];
+  saveMissings?: boolean;
 }
 
 export interface I18nOptionsFactory {

--- a/lib/middleware/i18n-language-middleware.ts
+++ b/lib/middleware/i18n-language-middleware.ts
@@ -10,20 +10,16 @@ export class I18nLanguageMiddleware implements NestMiddleware {
   ) {}
 
   use(req: any, res: any, next: () => void) {
-    try {
-      let language = null;
+    let language = null;
 
-      for (const resolver of this.i18nOptions.resolvers) {
-        language = resolver.resolve(req);
-        if (language !== undefined) {
-          break;
-        }
+    for (const resolver of this.i18nOptions.resolvers) {
+      language = resolver.resolve(req);
+      if (language !== undefined) {
+        break;
       }
-
-      req.i18nLang = language || this.i18nOptions.fallbackLanguage;
-    } catch (e) {
-      console.log(e);
     }
+    req.i18nLang = language || this.i18nOptions.fallbackLanguage;
+
     next();
   }
 }

--- a/lib/services/i18n.service.ts
+++ b/lib/services/i18n.service.ts
@@ -63,32 +63,37 @@ export class I18nService {
   }
 
   private saveMissingTranslation(key: string, language: string) {
-    console.log(key);
     const filePathMissing = path.join(this.i18nOptions.path, language);
     if (!fs.existsSync(filePathMissing)) {
       this.logger.error(`Cannot find path to store missing translations`);
       return;
     }
 
-    const fileName = path.join(filePathMissing, 'json.missing');
+    const keyParts = key.split('.');
+    const filePart = keyParts.shift();
+    const keyWithoutFile = keyParts.join('.');
+
+    const filePath = path.join(filePathMissing, `${filePart}.missing`);
 
     // first we get the content of the file
     let jsonContent = {};
-    if (fs.existsSync(fileName)) {
-      const fileContent = fs.readFileSync(fileName, { encoding: 'utf8' });
+    if (fs.existsSync(filePath)) {
+      const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
       jsonContent = JSON.parse(fileContent);
     }
 
     // check if the key is already present in our file
     // so we must not save the file again
-    if (_.has(jsonContent, key)) {
+    if (_.has(jsonContent, keyWithoutFile)) {
       return;
     }
 
     // and now we add the missing key
-    jsonContent = _.set(jsonContent, key, '');
+    jsonContent = _.set(jsonContent, keyWithoutFile, '');
 
-    fs.writeFileSync(fileName, JSON.stringify(jsonContent, null, 2));
-    this.logger.error(`The key "${key}" was added to the file "${fileName}"`);
+    fs.writeFileSync(filePath, JSON.stringify(jsonContent, null, 2));
+    this.logger.error(
+      `The key "${keyWithoutFile}" for language: ${language} was added to the file "${filePart}.missing" (@ ${filePath} )`,
+    );
   }
 }

--- a/lib/services/i18n.service.ts
+++ b/lib/services/i18n.service.ts
@@ -6,6 +6,9 @@ import {
   I18nTranslation,
 } from '../i18n.constants';
 import { I18nOptions } from '..';
+import * as fs from 'fs';
+import * as _ from 'lodash';
+import * as path from 'path';
 
 @Injectable()
 export class I18nService {
@@ -26,19 +29,26 @@ export class I18nService {
   ) {
     const { lang, args } = options;
     const translationsByLanguage = this.translations[lang];
-    const message = `translation "${key}" in "${lang}" doesn't exist.`;
+
     if (
-      (translationsByLanguage === undefined ||
-        translationsByLanguage === null ||
-        (!!translationsByLanguage &&
-          !translationsByLanguage.hasOwnProperty(key))) &&
-      lang !== this.i18nOptions.fallbackLanguage
+      translationsByLanguage === undefined ||
+      translationsByLanguage === null ||
+      (!!translationsByLanguage && !translationsByLanguage.hasOwnProperty(key))
     ) {
-      this.logger.error(message);
-      return this.translate(key, {
-        lang: this.i18nOptions.fallbackLanguage,
-        args: args,
-      });
+      // and now we detect, if this should also be added to the MISSING file
+      if (this.i18nOptions.saveMissings === true) {
+        this.saveMissingTranslation(key, lang);
+      }
+
+      if (lang !== this.i18nOptions.fallbackLanguage) {
+        const message = `Translation "${key}" in "${lang}" does not exist.`;
+        this.logger.error(message);
+
+        return this.translate(key, {
+          lang: this.i18nOptions.fallbackLanguage,
+          args: args,
+        });
+      }
     }
 
     let translation = translationsByLanguage[key];
@@ -50,5 +60,35 @@ export class I18nService {
       );
     }
     return translation || key;
+  }
+
+  private saveMissingTranslation(key: string, language: string) {
+    console.log(key);
+    const filePathMissing = path.join(this.i18nOptions.path, language);
+    if (!fs.existsSync(filePathMissing)) {
+      this.logger.error(`Cannot find path to store missing translations`);
+      return;
+    }
+
+    const fileName = path.join(filePathMissing, 'json.missing');
+
+    // first we get the content of the file
+    let jsonContent = {};
+    if (fs.existsSync(fileName)) {
+      const fileContent = fs.readFileSync(fileName, { encoding: 'utf8' });
+      jsonContent = JSON.parse(fileContent);
+    }
+
+    // check if the key is already present in our file
+    // so we must not save the file again
+    if (_.has(jsonContent, key)) {
+      return;
+    }
+
+    // and now we add the missing key
+    jsonContent = _.set(jsonContent, key, '');
+
+    fs.writeFileSync(fileName, JSON.stringify(jsonContent, null, 2));
+    this.logger.error(`The key "${key}" was added to the file "${fileName}"`);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4615,9 +4615,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.3.tgz",
-      "integrity": "sha512-ovDmF0c0VJDTP0VmwLetJQ+lVGyNqOkTniwO9S0MOJxGxIExpSRTL56/ZmvXZ1tHNA53GBbXQbfS8RnNGRXFjg==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.4.tgz",
+      "integrity": "sha512-RAt5ogbLRiKy9+T3dKbbPKP6tN2I9VjEtTXQFxdkauUdMjIBsS70ikwwSgsBR8xVVCUSX7sVDyWCyem5xB8YDw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -666,6 +666,12 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.137",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
+      "integrity": "sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -4874,8 +4880,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "",
   "author": "Toon van Strijp",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/testing": "^6.5.3",
     "@types/flat": "0.0.28",
     "@types/glob": "^7.1.1",
+    "@types/lodash": "^4.14.0",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.2",
     "@types/string-format": "^2.0.0",
@@ -44,6 +45,7 @@
   "dependencies": {
     "flat": "^4.1.0",
     "glob": "^7.1.4",
+    "lodash": "^4.17.0",
     "rxjs": "^6.5.2",
     "string-format": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fastify": "^2.7.1",
     "husky": "3.0.4",
     "jest": "^24.9.0",
-    "lint-staged": "9.2.3",
+    "lint-staged": "9.2.4",
     "prettier": "1.18.2",
     "reflect-metadata": "^0.1.13",
     "supertest": "^4.0.2",

--- a/tests/i18n-missing.spec.ts
+++ b/tests/i18n-missing.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+import * as fs from 'fs';
+import * as path from 'path';
+import { I18nModule, I18nService } from '../lib';
+
+describe('i18n module missing files', () => {
+  let i18nService: I18nService;
+
+  beforeAll(async () => {
+    const basePath = path.join(__dirname, 'i18n');
+
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRoot({
+          path: basePath,
+          fallbackLanguage: 'en',
+          saveMissings: true,
+        }),
+      ],
+    }).compile();
+
+    i18nService = module.get(I18nService);
+  });
+
+  afterAll(async () => {
+    const basePath = path.join(__dirname, 'i18n');
+
+    // remove the json.missing file from the i18n/LANG directory!
+    if (fs.existsSync(path.join(basePath, 'en', 'json.missing'))) {
+      fs.unlinkSync(path.join(basePath, 'en', 'json.missing'));
+    }
+  });
+
+  it('i18n service should be defined', async () => {
+    expect(i18nService).toBeTruthy();
+  });
+
+  it('should report missing translations', async () => {
+    // this will create the missing file
+    i18nService.translate('unknown.key', { lang: 'en' });
+
+    expect(
+      fs.existsSync(path.join(__dirname, 'i18n', 'en', 'json.missing')),
+    ).toBeTruthy();
+  });
+});

--- a/tests/i18n-missing.spec.ts
+++ b/tests/i18n-missing.spec.ts
@@ -26,8 +26,11 @@ describe('i18n module missing files', () => {
     const basePath = path.join(__dirname, 'i18n');
 
     // remove the json.missing file from the i18n/LANG directory!
-    if (fs.existsSync(path.join(basePath, 'en', 'json.missing'))) {
-      fs.unlinkSync(path.join(basePath, 'en', 'json.missing'));
+    const languages = ['en', 'nl'];
+    for (const language of languages) {
+      if (fs.existsSync(path.join(basePath, language, 'domain.missing'))) {
+        fs.unlinkSync(path.join(basePath, language, 'domain.missing'));
+      }
     }
   });
 
@@ -37,10 +40,22 @@ describe('i18n module missing files', () => {
 
   it('should report missing translations', async () => {
     // this will create the missing file
-    i18nService.translate('unknown.key', { lang: 'en' });
+    i18nService.translate('domain.unknown.key', { lang: 'en' });
 
     expect(
-      fs.existsSync(path.join(__dirname, 'i18n', 'en', 'json.missing')),
+      fs.existsSync(path.join(__dirname, 'i18n', 'en', 'domain.missing')),
+    ).toBeTruthy();
+  });
+
+  it('should report missing translations for various languages', async () => {
+    // this will create the missing file
+    i18nService.translate('domain.another.key', { lang: 'nl' });
+
+    expect(
+      fs.existsSync(path.join(__dirname, 'i18n', 'nl', 'domain.missing')),
+    ).toBeTruthy();
+    expect(
+      fs.existsSync(path.join(__dirname, 'i18n', 'en', 'domain.missing')),
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
This feature adds a new `saveMissing` flag to the options.
This flag, in turn, describes, if MISSING translations should automatically be saved to a  `json.missing` file in the respective `language` folder (e.g., `i18n/en`).

If you call
```ts 
i18n.translate('some.missing.key', { lang: 'en' });
```
a new `json.missing` file will be created with the following content:
```json
{
  "some": {
    "missing": {
      "key": ""
    }
  }
}
```

unfortunately i had to include `lodash` for this :(