### PR TITLE
fix: make @I18nLang() decorator access GQL Context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollographql/apollo-tools": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz",
+      "integrity": "sha512-7wEO+S+zgz/wVe3ilFQqICufRBYYDSNUkd1V03JWvXuSydbYq2SM5EgvWmFF+04iadt+aQ0XCCsRzCzRPQODfQ==",
+      "dev": true,
+      "requires": {
+        "apollo-env": "0.5.1"
+      }
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
+      "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -203,6 +218,16 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@dsherret/to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
       }
     },
     "@jest/console": {
@@ -438,6 +463,38 @@
         "uuid": "3.3.2"
       }
     },
+    "@nestjs/graphql": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-6.4.2.tgz",
+      "integrity": "sha512-VbRezeL/XbqH0NRxoxCtN+wmylC/aThzR46FRiJAKO2hx+LAtUgVXISF/+djfSBbgAx45bQrEjN68u4vK6kgNA==",
+      "dev": true,
+      "requires": {
+        "@types/graphql": "14.2.2",
+        "chokidar": "3.0.2",
+        "fast-glob": "3.0.4",
+        "graphql-tools": "4.0.5",
+        "lodash": "4.17.14",
+        "merge-graphql-schemas": "1.5.8",
+        "normalize-path": "3.0.0",
+        "ts-morph": "3.1.2",
+        "type-graphql": "^0.17.3",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
     "@nestjs/platform-express": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-6.5.3.tgz",
@@ -549,6 +606,70 @@
         "node-fetch": "^2.3.0"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -556,6 +677,15 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/babel__core": {
@@ -599,6 +729,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
@@ -608,11 +748,41 @@
         "commander": "*"
       }
     },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
+    },
+    "@types/cookies": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
+      "integrity": "sha512-jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
     },
     "@types/events": {
       "version": "3.0.0",
@@ -620,11 +790,41 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
+      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "@types/flat": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
       "integrity": "sha1-XHiBSdhabPj/X18ACs3ZEs3qQnQ=",
       "dev": true
+    },
+    "@types/fs-capacitor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
+      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -636,6 +836,30 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/graphql": {
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.2.tgz",
+      "integrity": "sha512-okXbUmdZFMO3AYBEJCcpJFPFDkKmIiZZBqWD5TmPtAv+GHfjD2qLZEI0PvZ8IWMU4ozoK2HV2lDxWjw4LbVlnw==",
+      "dev": true
+    },
+    "@types/graphql-upload": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
+      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/fs-capacitor": "*",
+        "@types/koa": "*",
+        "graphql": "^14.5.3"
+      }
+    },
+    "@types/http-assert": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
+      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -677,10 +901,51 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
+    "@types/keygrip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
+      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=",
+      "dev": true
+    },
+    "@types/koa": {
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz",
+      "integrity": "sha512-WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==",
+      "dev": true,
+      "requires": {
+        "@types/accepts": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/koa-compose": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.4.tgz",
+      "integrity": "sha512-ioou0rxkuWL+yBQYsHUQAzRTfVxAg8Y2VfMftU+Y3RA03/MzuFL0x/M2sXXj3PkfnENbHsjeHR1aMdezLYpTeA==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.137",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
       "integrity": "sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==",
+      "dev": true
+    },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -700,6 +965,29 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
+      "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
+      "dev": true,
+      "optional": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -732,6 +1020,22 @@
         "@types/superagent": "*"
       }
     },
+    "@types/validator": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.2.tgz",
+      "integrity": "sha512-k/ju1RsdP5ACFUWebqsyEy0avP5uNJCs2p3pmTHzOZdd4gMSAJTq7iUEHFY3tt3emBrPTm6oGvfZ4SzcqOgLPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@types/ws": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
+      "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -746,6 +1050,15 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
     },
     "abab": {
       "version": "2.0.0",
@@ -857,6 +1170,252 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "apollo-cache-control": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.1.tgz",
+      "integrity": "sha512-yQy5KB/OuX90PsdztWc4vfc4R//ZmW/AxNgXKWga0xW5OzEsysdJWHAsTzb40/rkJ9VNeQ+0N5wGikiS+jSCzg==",
+      "dev": true,
+      "requires": {
+        "apollo-server-env": "2.4.1",
+        "graphql-extensions": "0.8.1"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.8.1.tgz",
+          "integrity": "sha512-d/L4x7/PPWhviJqi7jIWOVJPzfzagYgPizSQUpa+3hozbWhwpWEnfxwgL5/If5MnPUikBnqlkOLCyjHMNdipYA==",
+          "dev": true,
+          "requires": {
+            "@apollographql/apollo-tools": "^0.4.0",
+            "apollo-server-env": "2.4.1",
+            "apollo-server-types": "0.2.1"
+          }
+        }
+      }
+    },
+    "apollo-datasource": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.1.tgz",
+      "integrity": "sha512-oy7c+9Up8PSZwJ1qTK9Idh1acDpIocvw+C0zcHg14ycvNz7qWHSwLUSaAjuQMd9SYFzB3sxfyEhyfyhIogT2+Q==",
+      "dev": true,
+      "requires": {
+        "apollo-server-caching": "0.5.0",
+        "apollo-server-env": "2.4.1"
+      }
+    },
+    "apollo-engine-reporting": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.3.tgz",
+      "integrity": "sha512-xv27qfc9dhi1yaWOhNQRmfF+SoLy74hl+M42arpIWdkoDe22fVTmTIqxqGwo4TFR3Z2OkAV5tNzuuOI/icd0Rg==",
+      "dev": true,
+      "requires": {
+        "apollo-engine-reporting-protobuf": "0.4.0",
+        "apollo-graphql": "^0.3.3",
+        "apollo-server-caching": "0.5.0",
+        "apollo-server-env": "2.4.1",
+        "apollo-server-types": "0.2.1",
+        "async-retry": "^1.2.1",
+        "graphql-extensions": "0.9.1"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.9.1.tgz",
+          "integrity": "sha512-JR/KStdwALd48B/xSG/Mi85zamuJd8THvVlzGM5juznPDN0wTYG5SARGzzvoqHxgxuUHYdzpvESwMAisORJdCQ==",
+          "dev": true,
+          "requires": {
+            "@apollographql/apollo-tools": "^0.4.0",
+            "apollo-server-env": "2.4.1",
+            "apollo-server-types": "0.2.1"
+          }
+        }
+      }
+    },
+    "apollo-engine-reporting-protobuf": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.0.tgz",
+      "integrity": "sha512-cXHZSienkis8v4RhqB3YG3DkaksqLpcxApRLTpRMs7IXNozgV7CUPYGFyFBEra1ZFgUyHXx4G9MpelV+n2cCfA==",
+      "dev": true,
+      "requires": {
+        "protobufjs": "^6.8.6"
+      }
+    },
+    "apollo-env": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
+      "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "apollo-graphql": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.3.tgz",
+      "integrity": "sha512-t3CO/xIDVsCG2qOvx2MEbuu4b/6LzQjcBBwiVnxclmmFyAxYCIe7rpPlnLHSq7HyOMlCWDMozjoeWfdqYSaLqQ==",
+      "dev": true,
+      "requires": {
+        "apollo-env": "0.5.1",
+        "lodash.sortby": "^4.7.0"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+      "dev": true,
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.19"
+      }
+    },
+    "apollo-server-caching": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.0.tgz",
+      "integrity": "sha512-l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.0.0"
+      }
+    },
+    "apollo-server-core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.0.tgz",
+      "integrity": "sha512-IvKIgqOqEEB8nszlpHWzlhAu4376So2PgNhFP6UrlfNTllt/WDti5YMOHnVimPWIDHmLPKFan0+wfzpsoRCRdg==",
+      "dev": true,
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.0",
+        "@apollographql/graphql-playground-html": "1.6.24",
+        "@types/graphql-upload": "^8.0.0",
+        "@types/ws": "^6.0.0",
+        "apollo-cache-control": "0.8.1",
+        "apollo-datasource": "0.6.1",
+        "apollo-engine-reporting": "1.4.3",
+        "apollo-server-caching": "0.5.0",
+        "apollo-server-env": "2.4.1",
+        "apollo-server-errors": "2.3.1",
+        "apollo-server-plugin-base": "0.6.1",
+        "apollo-server-types": "0.2.1",
+        "apollo-tracing": "0.8.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-extensions": "0.10.0",
+        "graphql-tag": "^2.9.2",
+        "graphql-tools": "^4.0.0",
+        "graphql-upload": "^8.0.2",
+        "sha.js": "^2.4.11",
+        "subscriptions-transport-ws": "^0.9.11",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "apollo-server-env": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.1.tgz",
+      "integrity": "sha512-J4G1Q6qyb7KjjqvQdVM5HUH3QDb52VK1Rv+MWL0rHcstJx9Fh/NK0sS+nujrMfKw57NVUs2d4KuYtl/EnW/txg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.1.2",
+        "util.promisify": "^1.0.0"
+      }
+    },
+    "apollo-server-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.1.tgz",
+      "integrity": "sha512-errZvnh0vUQChecT7M4A/h94dnBSRL213dNxpM5ueMypaLYgnp4hiCTWIEaooo9E4yMGd1qA6WaNbLDG2+bjcg==",
+      "dev": true
+    },
+    "apollo-server-express": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.0.tgz",
+      "integrity": "sha512-+057V6Ui1BX69jUlV6YDQ7Xw9CCBfowN/GauvyF09KnsjYUJ+cB1xf4mkj/HAjaz4ReXQaALJNr2qPYPXS4R6w==",
+      "dev": true,
+      "requires": {
+        "@apollographql/graphql-playground-html": "1.6.24",
+        "@types/accepts": "^1.3.5",
+        "@types/body-parser": "1.17.1",
+        "@types/cors": "^2.8.4",
+        "@types/express": "4.17.1",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "2.9.0",
+        "apollo-server-types": "0.2.1",
+        "body-parser": "^1.18.3",
+        "cors": "^2.8.4",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0",
+        "parseurl": "^1.3.2",
+        "subscriptions-transport-ws": "^0.9.16",
+        "type-is": "^1.6.16"
+      }
+    },
+    "apollo-server-plugin-base": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.1.tgz",
+      "integrity": "sha512-gLLF0kz4QOOyczDGWuR2ZNDfa1nHfyFNG76ue8Es0/0ujnMT9KoSokXkx1hDh0X7FFTMj/MelYYoNEqgTH88zw==",
+      "dev": true,
+      "requires": {
+        "apollo-server-types": "0.2.1"
+      }
+    },
+    "apollo-server-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.1.tgz",
+      "integrity": "sha512-ls26d6jjY7x91ctLWtbpQHGW0lcFR1LcOpDvBQUC2aCwQzuW/6yV7F3hfcEdLR9pjIxcA4yAtFQcKf5olDWVkA==",
+      "dev": true,
+      "requires": {
+        "apollo-engine-reporting-protobuf": "0.4.0",
+        "apollo-server-caching": "0.5.0",
+        "apollo-server-env": "2.4.1"
+      }
+    },
+    "apollo-tracing": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.1.tgz",
+      "integrity": "sha512-zhVNC7N6hg9IJEeSEXFDxcnXD5GJQAbHxaoKVBKEolcIIsz6EGd700ORdagJgFKLReVp9O65HPrZJCg66sVx7g==",
+      "dev": true,
+      "requires": {
+        "apollo-server-env": "2.4.1",
+        "graphql-extensions": "0.8.1"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.8.1.tgz",
+          "integrity": "sha512-d/L4x7/PPWhviJqi7jIWOVJPzfzagYgPizSQUpa+3hozbWhwpWEnfxwgL5/If5MnPUikBnqlkOLCyjHMNdipYA==",
+          "dev": true,
+          "requires": {
+            "@apollographql/apollo-tools": "^0.4.0",
+            "apollo-server-env": "2.4.1",
+            "apollo-server-types": "0.2.1"
+          }
+        }
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "dev": true,
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -896,6 +1455,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -918,6 +1483,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asn1": {
@@ -952,6 +1523,15 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
+      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "dev": true,
+      "requires": {
+        "retry": "0.12.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1060,6 +1640,12 @@
         "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1129,6 +1715,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1371,6 +1963,80 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chokidar": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
+      "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^3.0.1",
+        "braces": "^3.0.2",
+        "fsevents": "^2.0.6",
+        "glob-parent": "^5.0.0",
+        "is-binary-path": "^2.1.0",
+        "is-glob": "^4.0.1",
+        "normalize-path": "^3.0.0",
+        "readdirp": "^3.1.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
+          "integrity": "sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+          "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+          "dev": true,
+          "optional": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1398,6 +2064,18 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "class-validator": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.10.0.tgz",
+      "integrity": "sha512-RvjxRlvoCvM/ojUq11j78ISpReGdBoMErdmDk1e27aQZK6ppSXq751UE6jB9JI7ayEnL6Nnmllzn/HXVSu3dmg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/validator": "10.11.2",
+        "google-libphonenumber": "^3.1.6",
+        "validator": "11.1.0"
       }
     },
     "clean-stack": {
@@ -1485,6 +2163,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-block-writer": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-9.4.1.tgz",
+      "integrity": "sha512-LHAB+DL4YZDcwK8y/kAxZ0Lf/ncwLh/Ux4cTVWbPwIdrf1gPxXiPcwpz8r8/KqXu1aD+Raz46EOxDjFlbyO6bA==",
       "dev": true
     },
     "code-point-at": {
@@ -1606,6 +2290,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
       "dev": true
     },
     "core-util-is": {
@@ -1839,6 +2529,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
       "dev": true
     },
     "destroy": {
@@ -2107,6 +2803,12 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.2",
@@ -2746,6 +3448,23 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
+    },
+    "fs-capacitor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
+      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3394,11 +4113,108 @@
         "slash": "^3.0.0"
       }
     },
+    "google-libphonenumber": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.3.tgz",
+      "integrity": "sha512-8n4JyRptifaIRlHANKRlfqLR8fANm7+Q+1qvDuUsUeStSLtLGTVsZWe1llWDfgWTm1y07cEUyiRuNIv6cs2ovg==",
+      "dev": true,
+      "optional": true
+    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
+    },
+    "graphql": {
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.3.tgz",
+      "integrity": "sha512-W8A8nt9BsMg0ZK2qA3DJIVU6muWhxZRYLTmc+5XGwzWzVdUdPVlAAg5hTBjiTISEnzsKL/onasu6vl3kgGTbYg==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-extensions": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.0.tgz",
+      "integrity": "sha512-qz9Ev0NgsRxdTYqYSCpYwBWS9r1imm+vCBt3PmHzqZlE7SEpUPGddn9oKcLRB/P8uXT6dsr60hDmDHukIxiVOw==",
+      "dev": true,
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.0",
+        "apollo-server-env": "2.4.1",
+        "apollo-server-types": "0.2.1"
+      }
+    },
+    "graphql-query-complexity": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-query-complexity/-/graphql-query-complexity-0.3.0.tgz",
+      "integrity": "sha512-JVqHT81Eh9O17iOjs1r1qzsh5YY2upfA3zoUsQGggT4d+1hajWitk4GQQY5SZtq5eul7y6jMsM9qRUSOAKhDJQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "lodash.get": "^4.4.2"
+      }
+    },
+    "graphql-subscriptions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+      "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.1"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
+      "dev": true
+    },
+    "graphql-tools": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
+      "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
+    },
+    "graphql-upload": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz",
+      "integrity": "sha512-gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==",
+      "dev": true,
+      "requires": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.4",
+        "http-errors": "^1.7.2",
+        "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "busboy": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+          "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+          "dev": true,
+          "requires": {
+            "dicer": "0.3.0"
+          }
+        },
+        "dicer": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+          "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+          "dev": true,
+          "requires": {
+            "streamsearch": "0.1.2"
+          }
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -3653,6 +4469,16 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3678,6 +4504,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -3784,6 +4619,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3861,6 +4702,15 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3881,6 +4731,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3990,6 +4849,12 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
+    },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
+      "dev": true
     },
     "iterare": {
       "version": "1.2.0",
@@ -4548,6 +5413,15 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4897,6 +5771,13 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true,
+      "optional": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -4960,6 +5841,12 @@
         }
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4967,6 +5854,15 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
       }
     },
     "lru-queue": {
@@ -5053,6 +5949,25 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-graphql-schemas": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/merge-graphql-schemas/-/merge-graphql-schemas-1.5.8.tgz",
+      "integrity": "sha512-0TGOKebltvmWR9h9dPYS2vAqMPThXwJ6gVz7O5MtpBp2sunAg/M25iMSNI7YhU6PDJVtGtldTfqV9a+55YhB+A==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^2.2.1",
+        "glob": "^7.1.3",
+        "is-glob": "^4.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+          "dev": true
+        }
+      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -5211,6 +6126,19 @@
         "on-finished": "^2.3.0",
         "type-is": "^1.6.4",
         "xtend": "^4.0.0"
+      }
+    },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "nan": {
@@ -5395,6 +6323,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-path": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
       "dev": true
     },
     "object-visit": {
@@ -5786,6 +6720,35 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
+          "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==",
+          "dev": true
+        }
+      }
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -5916,6 +6879,15 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
+      "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
       }
     },
     "realpath-native": {
@@ -6100,6 +7072,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {
@@ -6321,6 +7299,16 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6752,6 +7740,19 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "subscriptions-transport-ws": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "dev": true,
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
+      }
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -6930,6 +7931,15 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-jest": {
       "version": "24.0.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.2.tgz",
@@ -6962,6 +7972,22 @@
             "camelcase": "^4.1.0"
           }
         }
+      }
+    },
+    "ts-morph": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-3.1.2.tgz",
+      "integrity": "sha512-5lCluMGhCLUTjYu9cM48m84slDMkHZV1l/znPDBPYxeZZX3a3jQsgQ3yz8vH2/yoaMTbacMF+L2g+/sdN7+ZOw==",
+      "dev": true,
+      "requires": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "code-block-writer": "9.4.1",
+        "fs-extra": "^8.1.0",
+        "glob-parent": "^5.0.0",
+        "globby": "^10.0.1",
+        "is-negated-glob": "^1.0.0",
+        "multimatch": "^4.0.0",
+        "typescript": "^3.0.1"
       }
     },
     "tslib": {
@@ -7006,6 +8032,33 @@
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
     },
+    "type-graphql": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-0.17.5.tgz",
+      "integrity": "sha512-wscr63K0j9UKcX/nBTySamLd7nMZeYKmADk8A9sVmcPh+clNJUAw96784dg2VZn/sUdmN1y2AeKzmTjCfVB5sA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "@types/node": "*",
+        "@types/semver": "^6.0.1",
+        "class-validator": ">=0.9.1",
+        "glob": "^7.1.4",
+        "graphql-query-complexity": "^0.3.0",
+        "graphql-subscriptions": "^1.1.0",
+        "semver": "^6.2.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -7048,6 +8101,12 @@
         }
       }
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -7059,6 +8118,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -7164,6 +8229,13 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==",
+      "dev": true,
+      "optional": true
     },
     "vary": {
       "version": "1.1.2",
@@ -7308,6 +8380,12 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
+    },
     "yargs": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
@@ -7334,6 +8412,22 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
+      "dev": true
+    },
+    "zen-observable-ts": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
+      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@nestjs/common": "^6.5.3",
     "@nestjs/core": "^6.5.3",
+    "@nestjs/graphql": "^6.4.2",
     "@nestjs/platform-express": "^6.5.3",
     "@nestjs/platform-fastify": "^6.5.3",
     "@nestjs/testing": "^6.5.3",
@@ -37,7 +38,10 @@
     "@types/node": "^12.7.2",
     "@types/string-format": "^2.0.0",
     "@types/supertest": "^2.0.8",
+    "apollo-server-express": "^2.8.1",
     "fastify": "^2.7.1",
+    "graphql": "^14.4.2",
+    "graphql-tools": "^4.0.5",
     "husky": "3.0.4",
     "jest": "^24.9.0",
     "lint-staged": "9.2.4",

--- a/src/lib/decorators/i18n-lang.decorator.ts
+++ b/src/lib/decorators/i18n-lang.decorator.ts
@@ -1,5 +1,19 @@
 import { createParamDecorator } from '@nestjs/common';
 
 export const I18nLang = createParamDecorator((data, req) => {
-  return req.i18nLang || (req.raw ? req.raw.i18nLang : undefined);
+  // this is gonna be so nasty..
+  // FIXME: This has to be fixed in later stages! PLEASE!
+  if (Array.isArray(req)) {
+    return resolveI18nLangaugeFromGraphQLContext(req);
+  }
+  return resolveI18nLanguageFromRestRequest(req);
 });
+
+function resolveI18nLanguageFromRestRequest(req) {
+  return req.i18nLang || (req.raw ? req.raw.i18nLang : undefined);
+}
+
+function resolveI18nLangaugeFromGraphQLContext(req) {
+  const [root, args, ctx, info] = req;
+  return ctx.req.i18nLang;
+}

--- a/tests/app/cats/cat.model.ts
+++ b/tests/app/cats/cat.model.ts
@@ -1,0 +1,6 @@
+export interface CatModel {
+  id: number;
+  name: string;
+  age: number;
+  description?: string;
+}

--- a/tests/app/cats/cat.module.ts
+++ b/tests/app/cats/cat.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CatResolver } from './cat.resolver';
+import { CatService } from './cat.service';
+
+@Module({
+  providers: [CatService, CatResolver],
+})
+export class CatModule {}

--- a/tests/app/cats/cat.resolver.ts
+++ b/tests/app/cats/cat.resolver.ts
@@ -1,0 +1,24 @@
+import { Resolver, Args, Query } from '@nestjs/graphql';
+import { CatService } from './cat.service';
+import { I18nLang, I18nService } from '../../../src/lib';
+
+@Resolver('Cat')
+export class CatResolver {
+  constructor(
+    private readonly catService: CatService,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  @Query('cats')
+  async getCats() {
+    return await this.catService.findAll();
+  }
+
+  @Query('cat')
+  async getCat(@Args('id') id: number, @I18nLang() lang: string) {
+    const cat = await this.catService.findById(id);
+    // we manually overwrite this property to indicate a value that is translated!
+    cat.description = this.i18nService.translate('test.cat', { lang: lang });
+    return cat;
+  }
+}

--- a/tests/app/cats/cat.service.ts
+++ b/tests/app/cats/cat.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { CatModel } from './cat.model';
+
+@Injectable()
+export class CatService {
+  private cats: CatModel[] = [
+    {
+      id: 1,
+      name: 'foo',
+      age: 4,
+    },
+    {
+      id: 2,
+      name: 'bar',
+      age: 6,
+    },
+  ];
+
+  constructor() {}
+
+  findAll(): CatModel[] {
+    return this.cats;
+  }
+
+  findById(id: number): CatModel {
+    return this.cats.find(cat => cat.id === id);
+  }
+}

--- a/tests/app/cats/cat.types.graphql
+++ b/tests/app/cats/cat.types.graphql
@@ -1,0 +1,11 @@
+type Cat {
+  id: Int
+  name: String
+  age: Int
+  description: String
+}
+
+type Query {
+  cats: [Cat]
+  cat(id: Int!): Cat
+}

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { I18nLang, I18nService } from '../../src/lib';
+import { I18nLang, I18nService } from '../../../src/lib';
 
 @Controller('hello')
 export class HelloController {

--- a/tests/i18n-express.e2e.spec.ts
+++ b/tests/i18n-express.e2e.spec.ts
@@ -3,9 +3,9 @@ import * as path from 'path';
 import { HeaderResolver, I18nModule, QueryResolver } from '../src/lib';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { HelloController } from './controllers/hello.controller';
+import { HelloController } from './app/controllers/hello.controller';
 
-describe('i18n module e2e', () => {
+describe('i18n module e2e express', () => {
   let app: INestApplication;
 
   beforeAll(async () => {

--- a/tests/i18n-fastify.e2e.spec.ts
+++ b/tests/i18n-fastify.e2e.spec.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { HeaderResolver, I18nModule, QueryResolver } from '../src/lib';
 import { Module } from '@nestjs/common';
-import { HelloController } from './controllers/hello.controller';
+import { HelloController } from './app/controllers/hello.controller';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -24,7 +24,7 @@ import { Test } from '@nestjs/testing';
 })
 export class AppModule {}
 
-describe('i18n module e2e', () => {
+describe('i18n module e2e fastify', () => {
   let app: NestFastifyApplication;
 
   beforeAll(async () => {

--- a/tests/i18n-gql.e2e.spec.ts
+++ b/tests/i18n-gql.e2e.spec.ts
@@ -1,0 +1,81 @@
+import { Test } from '@nestjs/testing';
+import * as path from 'path';
+import { HeaderResolver, I18nModule, QueryResolver } from '../src/lib';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { HelloController } from './app/controllers/hello.controller';
+import { GraphQLModule } from '@nestjs/graphql';
+import { CatModule } from './app/cats/cat.module';
+
+describe('i18n module e2e graphql', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        I18nModule.forRoot({
+          path: path.join(__dirname, '/i18n/'),
+          fallbackLanguage: 'en',
+          saveMissing: false,
+          resolvers: [new HeaderResolver()],
+        }),
+        GraphQLModule.forRoot({
+          typePaths: ['*/**/*.graphql'],
+          context: ({ req }) => ({ req }),
+          path: '/graphql',
+        }),
+        CatModule,
+      ],
+      controllers: [HelloController],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should query a particular cat in NL`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('accept-language', 'nl')
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{cat(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          cat: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Kat',
+          },
+        },
+      });
+  });
+
+  it(`should query a particular cat in EN`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('accept-language', 'en')
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{cat(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          cat: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Cat',
+          },
+        },
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/tests/i18n/en/test.json
+++ b/tests/i18n/en/test.json
@@ -9,5 +9,6 @@
     "TWO",
     "THREE"
   ],
+  "cat": "Cat",
   "ONLY_EN_KEY": "this key only exists in en lang"
 }

--- a/tests/i18n/nl/test.json
+++ b/tests/i18n/nl/test.json
@@ -7,5 +7,6 @@
     "EEN",
     "TWEE",
     "DRIE"
-  ]
+  ],
+  "cat": "Kat"
 }


### PR DESCRIPTION
This PR is some kind of FIX.
Previously, the `@I18nLang()` decorator was not able to resolve the language when running in `GraphQl` Context. This PR adds this feature.
Most of the PR, however, is testing code :(