### PR TITLE
Fix: fix bug in translate() method

### DIFF
--- a/src/lib/services/i18n.service.ts
+++ b/src/lib/services/i18n.service.ts
@@ -27,7 +27,15 @@ export class I18nService {
       args?: Array<{ [k: string]: any } | string> | { [k: string]: any };
     },
   ) {
+    options = {
+      ...{
+        lang: this.i18nOptions.fallbackLanguage,
+      },
+      ...options,
+    };
+
     const { lang, args } = options;
+
     const translationsByLanguage = this.translations[lang];
 
     if (

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -28,6 +28,10 @@ describe('i18n module', () => {
     expect(i18nService.translate('test.HELLO', { lang: 'nl' })).toBe('Hallo');
   });
 
+  it('i18n service should fallback to the fallback language if none is provided', async () => {
+    expect(i18nService.translate('test.HELLO')).toBe('Hello');
+  });
+
   it('i18n service should return nested translation', async () => {
     expect(
       i18nService.translate('test.PRODUCT.NEW', {


### PR DESCRIPTION
This PR fixes a bug in the `I18nService.translate()` method.
Based on the signature, the `options?` param is optional - however, due to the `destruct` operator in the method, it is not.

I added a "sane default" for the options (i.e., the language is set to the fallback language)

All the best