### PR TITLE
Use accept-language-parser for HeaderResolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,6 +1423,11 @@
       "resolved": "https://registry.npmjs.org/accept-language-negotiator/-/accept-language-negotiator-1.2.0.tgz",
       "integrity": "sha512-f6LrLgHk8d/F94d/j2b7KwaWNAFqfEl0ftsf2ZGxEih2xyy864ainNhKEMP1EdZRQYwgLjwZonrda3v8jnNgHA=="
     },
+    "accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "accept-language-negotiator": "^1.2.0",
+    "accept-language-parser": "^1.5.0",
     "chalk": "^3.0.0",
     "commander": "^4.1.1",
     "cookie": "^0.4.0",

--- a/src/lib/middleware/i18n-language-middleware.ts
+++ b/src/lib/middleware/i18n-language-middleware.ts
@@ -25,7 +25,7 @@ export class I18nLanguageMiddleware implements NestMiddleware {
 
   async use(req: any, res: any, next: () => void) {
     let language = null;
-
+    req.i18nService = this.i18nService;
     for (const r of this.i18nResolvers) {
       const resolver = await this.getResolver(r);
 
@@ -36,7 +36,6 @@ export class I18nLanguageMiddleware implements NestMiddleware {
       }
     }
     req.i18nLang = language || this.i18nOptions.fallbackLanguage;
-    req.i18nService = this.i18nService;
 
     next();
   }

--- a/src/lib/resolvers/header.resolver.ts
+++ b/src/lib/resolvers/header.resolver.ts
@@ -2,6 +2,8 @@ import { I18nResolver } from '../index';
 import { Injectable } from '@nestjs/common';
 import { I18nResolverOptions } from '../decorators/i18n-resolver-options.decorator';
 import { I18nLanguages } from '../decorators/i18n-languages.decorator';
+import { I18nService } from '../services/i18n.service';
+import { pick } from 'accept-language-parser';
 
 @Injectable()
 export class HeaderResolver implements I18nResolver {
@@ -20,6 +22,7 @@ export class HeaderResolver implements I18nResolver {
       }
     }
 
-    return lang;
+    const service: I18nService = req.i18nService;
+    return pick(service.getSupportedLanguages(), lang);
   }
 }

--- a/src/lib/resolvers/header.resolver.ts
+++ b/src/lib/resolvers/header.resolver.ts
@@ -22,7 +22,11 @@ export class HeaderResolver implements I18nResolver {
       }
     }
 
-    const service: I18nService = req.i18nService;
-    return pick(service.getSupportedLanguages(), lang);
+    if (!lang) {
+      return lang;
+    } else {
+      const service: I18nService = req.i18nService;
+      return pick(service.getSupportedLanguages(), lang);
+    }
   }
 }

--- a/tests/i18n-fastify.e2e.spec.ts
+++ b/tests/i18n-fastify.e2e.spec.ts
@@ -71,7 +71,7 @@ describe('i18n module e2e fastify', () => {
         url: '/hello',
         method: 'GET',
         headers: {
-          'accept-language': 'nl',
+          'accept-language': 'nl-NL,nl;q=0.5',
         },
       })
       .then(({ payload }) => expect(payload).toBe('Hallo'));
@@ -83,7 +83,7 @@ describe('i18n module e2e fastify', () => {
         url: '/hello',
         method: 'GET',
         headers: {
-          'accept-language': 'nl',
+          'accept-language': 'nl-NL,nl;q=0.5',
         },
       })
       .then(({ payload }) => expect(payload).toBe('Hallo'));
@@ -134,7 +134,7 @@ describe('i18n module e2e fastify', () => {
         url: '/hello/context',
         method: 'GET',
         headers: {
-          'accept-language': 'nl',
+          'accept-language': 'nl-NL,nl;q=0.5',
         },
       })
       .then(({ payload }) => expect(payload).toBe('Hallo'));
@@ -185,7 +185,7 @@ describe('i18n module e2e fastify', () => {
         url: '/hello/request-scope',
         method: 'GET',
         headers: {
-          'accept-language': 'nl',
+          'accept-language': 'nl-NL,nl;q=0.5',
         },
       })
       .then(({ payload }) => expect(payload).toBe('Hallo'));


### PR DESCRIPTION
The accept-language field in request header is not just a simple language code; it could be a list of languages, with q-factor weighting. (See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language))

To parse this string, we need `accept-language-parser`. I've added a call to this package in HeaderResolver.

I also modified the tests and replaced the accept-language header so that they can better reflect real world scenarios.

This solves #64 

The reason a separate resolver is not needed is because: Accept-Language is a HTTP standard. A standard should be respected in the default implementation, and resolvers that do not respect the standard should not be included in this package.