### PR TITLE
Issue/loose matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "description": "",
   "author": "Toon van Strijp",
   "license": "MIT",

--- a/src/resolvers/accept-language.resolver.ts
+++ b/src/resolvers/accept-language.resolver.ts
@@ -27,9 +27,9 @@ export class AcceptLanguageResolver implements I18nResolver {
     const lang = req.raw
       ? req.raw.headers['accept-language']
       : req.headers['accept-language'];
-      
+
     if (lang) {
-      return pick(await service.getSupportedLanguages(), lang);
+      return pick(await service.getSupportedLanguages(), lang, {loose: true });
     }
     return lang;
   }

--- a/tests/i18n-express.e2e.spec.ts
+++ b/tests/i18n-express.e2e.spec.ts
@@ -25,6 +25,7 @@ describe('i18n module e2e express', () => {
             'en-CA': 'fr',
             'en-*': 'en',
             'fr-*': 'fr',
+            'fr': 'fr-FR',
             pt: 'pt-BR',
           },
           resolvers: [
@@ -413,6 +414,14 @@ describe('i18n module e2e express', () => {
       .set('accept-language', 'nl-NL,nl;q=0.5')
       .expect(200)
       .expect('Hallo');
+  });
+
+  it(`/GET hello/request-scope should return translation when providing wildcard accept-language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/request-scope')
+      .set('accept-language', 'fr-FR')
+      .expect(200)
+      .expect('Bonjour');
   });
 
   it(`/GET hello/request-scope should return translation when providing cookie`, () => {


### PR DESCRIPTION
This PR fixes very basic bug where AcceptHeaderResolver won't match e.g 'en-us' to 'en-*'.
pick() from accept-language-parser cannot parse wildcarded supported languages as 'en-*'.
Loose is not the best way to do it, however it works without changing lib for parsing lang.

Regression test should be self explanatory.