### PR TITLE
Fix an issue with the HeaderResolver when the request includes no headers.

### DIFF
--- a/src/resolvers/header.resolver.ts
+++ b/src/resolvers/header.resolver.ts
@@ -31,7 +31,7 @@ export class HeaderResolver implements I18nResolver {
             'HeaderResolver does not support RFC4647 Accept-Language header. Please use AcceptLanguageResolver instead.',
           );
         }
-        if (req.headers[key] !== undefined) {
+        if (req.headers !== undefined && req.headers[key] !== undefined) {
           lang = req.headers[key];
           break;
         }


### PR DESCRIPTION
When the request includes no headers, "HeaderResolver" creates an error "Cannot read property 'xxx' of undefined", where "xxx" is the name of the expected header.