### PR TITLE
Make error logging optional

### DIFF
--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -40,6 +40,7 @@ const logger = new Logger('I18nService');
 
 const defaultOptions: Partial<I18nOptions> = {
   resolvers: [],
+  logging: true
 };
 
 @Global()
@@ -169,6 +170,11 @@ export class I18nModule implements OnModuleInit {
       useClass: options.parser,
     };
 
+    const i18nOptions: ValueProvider = {
+      provide: I18N_OPTIONS,
+      useValue: options,
+    };
+
     const i18nLanguagesSubjectProvider: ValueProvider = {
       provide: I18N_LANGUAGES_SUBJECT,
       useValue: i18nLanguagesSubject,
@@ -193,6 +199,7 @@ export class I18nModule implements OnModuleInit {
         asyncLanguagesProvider,
         asyncParserOptionsProvider,
         I18nService,
+        i18nOptions,
         I18nRequestScopeService,
         resolversProvider,
         i18nParserProvider,

--- a/src/interfaces/i18n-options.interface.ts
+++ b/src/interfaces/i18n-options.interface.ts
@@ -24,6 +24,7 @@ export interface I18nOptions {
   resolvers?: I18nOptionResolver[];
   parser: Type<I18nParser>;
   parserOptions: any;
+  logging?: boolean;
 }
 
 export interface I18nOptionsFactory {
@@ -42,4 +43,5 @@ export interface I18nAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   resolvers?: I18nOptionResolver[];
   parser: Type<I18nParser>;
   inject?: any[];
+  logging?: boolean;
 }

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -71,7 +71,8 @@ export class I18nService {
       translationsByLanguage === null ||
       !translation
     ) {
-      if (lang !== this.i18nOptions.fallbackLanguage) {
+      if (lang !== this.i18nOptions.fallbackLanguage &&
+        this.i18nOptions.logging) {
         const message = `Translation "${key}" in "${lang}" does not exist.`;
         this.logger.error(message);
 
@@ -136,7 +137,7 @@ export class I18nService {
       const pluralObject = this.getPluralObject(translation);
       if(pluralObject && args && args.hasOwnProperty('count')) {
         const count = Number(args['count']);
-        
+
         if(count == 0 && !!pluralObject.zero) {
           translation = pluralObject.zero
         } else if(count == 1 && !!pluralObject.one) {
@@ -216,7 +217,7 @@ export class I18nService {
           try {
             args = JSON.parse(result[3])
           }catch(e) {
-  
+
           }
         }
       }


### PR DESCRIPTION
Context
When there is a missing translation there is an error pushed to our logger. The idea of this PR is to make this logging optional  . The idea is to add a new parameter in i18n options.

Features
- add logging parameter in the i18n options
- enable logging only if the passed parameter is true
- logging parameter is set to true by default so we can avoid breaking changes
