### PR TITLE
fix wrong passing of i18n functions.

### DIFF
--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -172,7 +172,7 @@ export class I18nModule implements OnModuleInit {
 
     const i18nOptions: ValueProvider = {
       provide: I18N_OPTIONS,
-      useValue: options,
+      useValue: options.useFactory(),
     };
 
     const i18nLanguagesSubjectProvider: ValueProvider = {


### PR DESCRIPTION
The mistake was made in order to cover the async initialize of the i18n module.
I18n options are passed differently in async and sync module init.
Tests are fixed:

![Screenshot 2021-11-28 at 22 12 13](https://user-images.githubusercontent.com/45165261/143784261-fb247a24-cc01-4903-8f08-ba458a0a5aa6.png)
 
