### PR TITLE
Fix translation with disabled logging

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -75,12 +75,12 @@ export class I18nService {
         this.i18nOptions.logging) {
         const message = `Translation "${key}" in "${lang}" does not exist.`;
         this.logger.error(message);
-
-        return this.translate(key, {
-          lang: this.i18nOptions.fallbackLanguage,
-          args,
-        });
       }
+
+      return this.translate(key, {
+        lang: this.i18nOptions.fallbackLanguage,
+        args,
+      });
     }
 
     return translation || key;

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -71,16 +71,16 @@ export class I18nService {
       translationsByLanguage === null ||
       !translation
     ) {
-      if (lang !== this.i18nOptions.fallbackLanguage &&
-        this.i18nOptions.logging) {
-        const message = `Translation "${key}" in "${lang}" does not exist.`;
-        this.logger.error(message);
+      if (lang !== this.i18nOptions.fallbackLanguage) {
+        if (this.i18nOptions.logging) {
+          const message = `Translation "${key}" in "${lang}" does not exist.`;
+          this.logger.error(message);
+        }
+        return this.translate(key, {
+          lang: this.i18nOptions.fallbackLanguage,
+          args,
+        });
       }
-
-      return this.translate(key, {
-        lang: this.i18nOptions.fallbackLanguage,
-        args,
-      });
     }
 
     return translation || key;


### PR DESCRIPTION
I was trying to use the fallback mechanism for my project, but when the translation does not exist it will print an error in the console. I wanted to disable these errors, so I used  the "i18nOptions.logging" option and it works, but then the message remains untranslated. I think someone may have misplaced the bracket here, as the logging option should only disable error output.

My pull request makes it skip printing the message, when logging is disabled, and continuing to translate the message using the fallback language.