### PR TITLE
Add matchType option to AcceptLanguageResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ To make it easier to manage in what language to respond you can make use of reso
       resolvers: [
         { use: QueryResolver, options: ['lang', 'locale', 'l'] },
         new HeaderResolver(['x-custom-lang']),
-        AcceptLanguageResolver,
+        { use: AcceptLanguageResolver, options: { matchType: 'strict-loose' } },
         new CookieResolver(['lang', 'locale', 'l']),
       ],
     }),

--- a/src/resolvers/accept-language.resolver.ts
+++ b/src/resolvers/accept-language.resolver.ts
@@ -1,10 +1,21 @@
-import { I18nResolver } from '../index';
+import { I18nResolver, I18nResolverOptions } from '../index';
 import { Injectable, ExecutionContext } from '@nestjs/common';
 import { pick } from 'accept-language-parser';
 import { I18nService } from '../services/i18n.service';
 
+interface AcceptLanguageResolverOptions {
+  matchType: 'strict' | 'loose' | 'strict-loose'
+}
+
 @Injectable()
 export class AcceptLanguageResolver implements I18nResolver {
+  constructor(
+    @I18nResolverOptions()
+    private options: AcceptLanguageResolverOptions = {
+      matchType: 'strict-loose'
+    }
+  ) {}
+
   async resolve(
     context: ExecutionContext,
   ): Promise<string | string[] | undefined> {
@@ -30,8 +41,12 @@ export class AcceptLanguageResolver implements I18nResolver {
 
     if (lang) {
       const supportedLangs = await service.getSupportedLanguages();
-      return pick(supportedLangs, lang)
-        ?? pick(supportedLangs, lang, { loose: true });
+      if (this.options.matchType === 'strict') {
+        return pick(supportedLangs, lang)
+      } else if (this.options.matchType === 'loose') {
+        return pick(supportedLangs, lang, { loose: true });
+      }
+      return pick(supportedLangs, lang) ?? pick(supportedLangs, lang, { loose: true })
     }
     return lang;
   }


### PR DESCRIPTION
This PR resolves an issue stated in #255. I originally wanted to add language mapping as a option to the `AcceptLanguageResolver`, but this would lead to some break changes or copy-pasting code from the `accept-language-parser` library in order to preserve consistency.

Allowing users to change language resolution will result to be able to handle situation like this:

`cs-CZ,en,*` => `cs` // 'loose' match type
`cs-CZ,en,*` => `en` // 'strict' match type
`cs-CZ,en-GB,*` => `cs` // 'strict-loose' match type

without any breaking changes.