### PR TITLE
add pluggable formatter functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-i18n",
-  "version": "8.2.2",
+  "version": "8.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-i18n",
-      "version": "8.2.2",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
@@ -22,6 +22,7 @@
         "@nestjs/platform-fastify": "^8.2.0",
         "@nestjs/testing": "^8.2.0",
         "@types/jest": "^27.0.3",
+        "@types/string-format": "^2.0.0",
         "@types/ws": "^8.2.0",
         "apollo-cache-inmemory": "^1.6.6",
         "apollo-client": "^2.6.10",
@@ -1751,6 +1752,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-mMwtmgN0ureESnJ3SuMM4W9lsi4CgOxs43YxNo14SDHgzJ+OPYO3yM7nOTJTh8x5YICseBdtrySUbvxnpb+NYQ==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -8565,6 +8572,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-mMwtmgN0ureESnJ3SuMM4W9lsi4CgOxs43YxNo14SDHgzJ+OPYO3yM7nOTJTh8x5YICseBdtrySUbvxnpb+NYQ==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "8.2.3",
+  "version": "8.3.0",
   "description": "",
   "author": "Toon van Strijp",
   "license": "MIT",
@@ -30,6 +30,7 @@
     "@nestjs/platform-fastify": "^8.2.0",
     "@nestjs/testing": "^8.2.0",
     "@types/jest": "^27.0.3",
+    "@types/string-format": "^2.0.0",
     "@types/ws": "^8.2.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -35,11 +35,13 @@ import { shouldResolve } from './utils/util';
 import { I18nTranslation } from './interfaces/i18n-translation.interface';
 import { I18nParser } from './parsers/i18n.parser';
 import { Observable, BehaviorSubject } from 'rxjs';
+import * as format from 'string-format';
 
 const logger = new Logger('I18nService');
 
 const defaultOptions: Partial<I18nOptions> = {
   resolvers: [],
+  formatter: format,
   logging: true
 };
 

--- a/src/interfaces/i18n-options.interface.ts
+++ b/src/interfaces/i18n-options.interface.ts
@@ -18,12 +18,18 @@ export type I18nOptionResolver =
   | Type<I18nResolver>
   | I18nResolver;
 
+export type Formatter = (
+  template: string,
+  ...args: (string | Record<string, string>)[]
+) => string;
+
 export interface I18nOptions {
   fallbackLanguage: string;
   fallbacks?: { [key: string]: string };
   resolvers?: I18nOptionResolver[];
   parser: Type<I18nParser>;
   parserOptions: any;
+  formatter?: Formatter;
   logging?: boolean;
 }
 

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import * as format from 'string-format';
 import {
   I18N_OPTIONS,
   I18N_TRANSLATIONS,
@@ -165,7 +164,7 @@ export class I18nService {
           };
         }, Promise.resolve({}));
       }
-      translation = format(
+      translation = this.i18nOptions.formatter(
         translation,
         ...(args instanceof Array ? args || [] : [args]),
       );


### PR DESCRIPTION
This resolves https://github.com/toonvanstrijp/nestjs-i18n/issues/271, but in a more generic way, by allowing users to supply their own formatter functions in place of the default `string-format` one.