### PR TITLE
I18n error formatter

### DIFF
--- a/docs/guides/dto-validation.md
+++ b/docs/guides/dto-validation.md
@@ -104,8 +104,8 @@ app.useGlobalFilters(new I18nValidationExceptionFilter());
 ```
 :::info
 
- `I18nValidationExceptionFilter` also takes an argument of type `I18nValidationExceptionFilterOptions` for simplifying error messages.
- `new I18nValidationExceptionFilter({detailedErrors: false})` will return the simplified error message.
+`I18nValidationExceptionFilter` also takes an argument of type `I18nValidationExceptionFilterOptions` for simplifying error messages.
+`new I18nValidationExceptionFilter({detailedErrors: false})` will return the simplified error message. `new I18nValidationExceptionFilter({errorFormatter: /* your custom error formatter function */ })` will return the validation errors in a format that you specify. Note that only one of the properties can be used at the time.
 
 :::
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-i18n",
-  "version": "9.0.12",
+  "version": "9.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-i18n",
-      "version": "9.0.12",
+      "version": "9.0.13",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",

--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -38,9 +38,7 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
     response.status(exception.getStatus()).send({
       statusCode: exception.getStatus(),
       message: exception.getResponse(),
-      errors: this.options.detailedErrors
-        ? errors
-        : this.flattenValidationErrors(errors),
+      errors: this.normalizeErrors(errors),
     });
   }
 
@@ -64,6 +62,19 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
       );
       return error;
     });
+  }
+
+  protected normalizeErrors(
+    validationErrors: ValidationError[],
+  ): string[] | I18nValidationError[] | object {
+    switch (true) {
+      case !this.options.detailedErrors && !('errorFormatter' in this.options):
+        return this.flattenValidationErrors(validationErrors);
+      case !this.options.detailedErrors && 'errorFormatter' in this.options:
+        return this.options.errorFormatter(validationErrors);
+      default:
+        return validationErrors;
+    }
   }
 
   protected flattenValidationErrors(

--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -10,7 +10,7 @@ import {
   I18nValidationExceptionFilterErrorFormatterOption,
 } from 'src/interfaces/i18n-validation-exception-filter.interface';
 import { Either } from 'src/types/either.type';
-import { mapChildrenToValidationErrors } from 'src/utils/format';
+import { mapChildrenToValidationErrors } from '../utils/format';
 import { I18nContext } from '../i18n.context';
 import {
   I18nValidationError,

--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -39,7 +39,7 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
     response.status(exception.getStatus()).send({
       statusCode: exception.getStatus(),
       message: exception.getResponse(),
-      errors: this.normalizeErrors(errors),
+      errors: this.normalizeValidationErrors(errors),
     });
   }
 
@@ -65,7 +65,7 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
     });
   }
 
-  protected normalizeErrors(
+  protected normalizeValidationErrors(
     validationErrors: ValidationError[],
   ): string[] | I18nValidationError[] | object {
     switch (true) {

--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -5,6 +5,11 @@ import {
   ValidationError,
 } from '@nestjs/common';
 import iterate from 'iterare';
+import {
+  I18nValidationExceptionFilterDetailedErrorsOption,
+  I18nValidationExceptionFilterErrorFormatterOption,
+} from 'src/interfaces/i18n-validation-exception-filter.interface';
+import { Either } from 'src/types/either.type';
 import { I18nContext } from '../i18n.context';
 import {
   I18nValidationError,
@@ -12,9 +17,10 @@ import {
 } from '../interfaces/i18n-validation-error.interface';
 import { getI18nContextFromArgumentsHost } from '../utils/util';
 
-interface I18nValidationExceptionFilterOptions {
-  detailedErrors?: boolean;
-}
+type I18nValidationExceptionFilterOptions = Either<
+  I18nValidationExceptionFilterDetailedErrorsOption,
+  I18nValidationExceptionFilterErrorFormatterOption
+>;
 
 @Catch(I18nValidationException)
 export class I18nValidationExceptionFilter implements ExceptionFilter {

--- a/src/interfaces/i18n-validation-exception-filter.interface.ts
+++ b/src/interfaces/i18n-validation-exception-filter.interface.ts
@@ -1,0 +1,9 @@
+import { ValidationError } from '@nestjs/common';
+
+export interface I18nValidationExceptionFilterDetailedErrorsOption {
+  detailedErrors?: boolean;
+}
+
+export interface I18nValidationExceptionFilterErrorFormatterOption {
+  errorFormatter?: (errors: ValidationError[]) => object;
+}

--- a/src/types/either.type.ts
+++ b/src/types/either.type.ts
@@ -1,0 +1,3 @@
+import { Only } from './only.type';
+
+export type Either<T, U> = Only<T, U> | Only<U, T>;

--- a/src/types/only.type.ts
+++ b/src/types/only.type.ts
@@ -1,0 +1,5 @@
+export type Only<T, U> = {
+  [P in keyof T]: T[P];
+} & {
+  [P in keyof U]?: never;
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,33 @@
+import { ValidationError } from '@nestjs/common';
+
+export const mapChildrenToValidationErrors = (
+  error: ValidationError,
+  parentPath?: string,
+): ValidationError[] => {
+  if (!(error.children && error.children.length)) {
+    return [error];
+  }
+  const validationErrors = [];
+  parentPath = parentPath ? `${parentPath}.${error.property}` : error.property;
+  for (const item of error.children) {
+    if (item.children && item.children.length) {
+      validationErrors.push(...mapChildrenToValidationErrors(item, parentPath));
+    }
+    validationErrors.push(prependConstraintsWithParentProp(parentPath, item));
+  }
+  return validationErrors;
+};
+
+const prependConstraintsWithParentProp = (
+  parentPath: string,
+  error: ValidationError,
+): ValidationError => {
+  const constraints = {};
+  for (const key in error.constraints) {
+    constraints[key] = `${parentPath}.${error.constraints[key]}`;
+  }
+  return {
+    ...error,
+    constraints,
+  };
+};

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -21,6 +21,7 @@ import { TestException, TestExceptionFilter } from '../filter/test.filter';
 import { TestGuard } from '../guards/test.guard';
 import { GrpcMethod, Payload } from '@nestjs/microservices';
 import { Hero, HeroById } from '../interfaces/hero.interface';
+import { exampleErrorFormatter } from '../examples/example.functions';
 
 @Controller('hello')
 @UseFilters(new TestExceptionFilter())
@@ -158,6 +159,14 @@ export class HelloController {
   @Post('/validation-without-details')
   @UseFilters(new I18nValidationExceptionFilter({ detailedErrors: false }))
   validationWithoutDetails(@Body() createUserDto: CreateUserDto): any {
+    return 'This action adds a new user';
+  }
+
+  @Post('/validation-custom-formatter')
+  @UseFilters(new I18nValidationExceptionFilter({ 
+    errorFormatter: exampleErrorFormatter
+  }))
+  validationCustomFormatter(@Body() createUserDto: CreateUserDto): any {
     return 'This action adds a new user';
   }
 

--- a/tests/app/examples/example.functions.ts
+++ b/tests/app/examples/example.functions.ts
@@ -1,0 +1,17 @@
+import { ValidationError } from '@nestjs/common';
+import { mapChildrenToValidationErrors } from '../../../src/utils/format';
+
+export const exampleErrorFormatter = (errors: ValidationError[]) : object  => {
+  const errorMessages = {};
+
+  for (let foo = 0; foo < errors.length; foo = foo + 1) {
+    const mappedErrors = mapChildrenToValidationErrors(errors[foo]);
+    
+    for (let bar = 0; bar < mappedErrors.length; bar = bar + 1) {
+      const error = mappedErrors[bar];
+      errorMessages[error.property] = Object.values(error.constraints);
+    }
+  }
+
+  return errorMessages;
+}

--- a/tests/i18n-dto.e2e.spec.ts
+++ b/tests/i18n-dto.e2e.spec.ts
@@ -96,6 +96,114 @@ describe('i18n module e2e dto', () => {
     ],
   };
 
+  it(`should translate validation messages in a custom format if specified`, async () => {
+    await request(app.getHttpServer())
+      .post('/hello/validation-custom-formatter')
+      .send({
+        email: '',
+        password: '',
+        extra: { subscribeToEmail: '', min: 1, max: 100 },
+      })
+      .set('Accept', 'application/json')
+      .expect(400)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          statusCode: 400,
+          message: 'Bad Request',
+          errors: {
+            email: [
+              'email is invalid',
+              'email cannot be empty'
+            ],
+            password: [
+              'password cannot be empty'
+            ],
+            subscribeToEmail: [
+              'extra.subscribeToEmail is not a boolean'
+            ],
+            min: [
+              'extra.min with value: "1" needs to be at least 5, ow and COOL'
+            ],
+            max: [
+              'extra.max with value: "100" needs to be less than 10, ow and SUPER'
+            ]
+          },
+        });
+      });
+
+    await request(app.getHttpServer())
+      .post('/hello/validation-custom-formatter')
+      .send({
+        test: '',
+        email: '',
+        password: '',
+        extra: { subscribeToEmail: '', min: 1, max: 100 },
+      })
+      .set('Accept', 'application/json')
+      .expect(400)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          statusCode: 400,
+          message: 'Bad Request',
+          errors: {
+            test: [
+              'property test should not exist'
+            ],
+            email: [
+              'email is invalid',
+              'email cannot be empty'
+            ],
+            password: [
+              'password cannot be empty'
+            ],
+            subscribeToEmail: [
+              'extra.subscribeToEmail is not a boolean'
+            ],
+            min: [
+              'extra.min with value: "1" needs to be at least 5, ow and COOL'
+            ],
+            max: [
+              'extra.max with value: "100" needs to be less than 10, ow and SUPER'
+            ]
+          },
+        });
+      });
+
+    return request(app.getHttpServer())
+      .post('/hello/validation-custom-formatter?l=nl')
+      .send({
+        email: '',
+        password: '',
+        extra: { subscribeToEmail: '', min: 1, max: 100 },
+      })
+      .set('Accept', 'application/json')
+      .expect(400)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          statusCode: 400,
+          message: 'Bad Request',
+          errors: {
+            email: [
+              'email is ongeldig',
+              'e-mail adres mag niet leeg zijn'
+            ],
+            password: [
+              'wachtwoord mag niet leeg zijn'
+            ],
+            subscribeToEmail: [
+              'extra.subscribeToEmail is geen boolean'
+            ],
+            min: [
+              'extra.min met waarde: "1" moet hoger zijn dan 5, ow en COOL'
+            ],
+            max: [
+              'extra.max met waarde: "100" moet lager zijn dan 10, ow en SUPER'
+            ]
+          }
+        });
+      });
+  });
+
   it(`should translate validation messages without detailed errors`, async () => {
     await request(app.getHttpServer())
       .post('/hello/validation-without-details')


### PR DESCRIPTION
##  Description
This pull request adds the possibility to format the validation error messages using a custom self-written function. This self-written function can be defined in the `I18nValidationExceptionFilter`. See the example below.

```typescript
@UseFilters(new I18nValidationExceptionFilter({
 errorFormatter: (errors: ValidationError[]) : object  => {
   const formattedErrors = errors;

   // Custom implementation to format the errors

   return formattedErrors;
 }
}));
```

## Motivation and Context
Although [#327](https://github.com/toonvanstrijp/nestjs-i18n/pull/327) adds the possibility to flatten the validation errors, sometimes you want full control of how the errors are formatted. For example, I like to group the errors by the error's property so I can display them under a specific input field in the frontend.

## Notes
I moved the `mapChildrenToValidationErrors` method into a separate file. This way this function can be used as stand-alone in order to format the validation errors if necessary. The details of this pull request can be found in the `Files changed` tab.