### PR TITLE
Remove object merge from translate method

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -48,11 +48,6 @@ export class I18nService {
   }
 
   public translate<T = any>(key: string, options?: TranslateOptions): T {
-    options = {
-      lang: this.i18nOptions.fallbackLanguage,
-      ...options,
-    };
-
     const { defaultValue } = options;
     let { lang } = options;
 


### PR DESCRIPTION
Remove the following:
```
options = {
      lang: this.i18nOptions.fallbackLanguage,
      ...options,
    };
```

Since when we destructure `lang` from `options` if it's not available, the value of `lang` will be `undefined`, and we already checking its value and assigning it the `fallbackLanguage` if it's `undefined`. Therefore, using the above code is kind of redundant in my opinion.