### PR TITLE
refactor(loaders): replaced `fs` module with `fs/promises`

### DIFF
--- a/src/loaders/i18n.abstract.loader.ts
+++ b/src/loaders/i18n.abstract.loader.ts
@@ -2,9 +2,8 @@ import { I18nLoader } from './i18n.loader';
 import { I18N_LOADER_OPTIONS } from '../i18n.constants';
 import { Inject, OnModuleDestroy } from '@nestjs/common';
 import * as path from 'path';
-import * as fs from 'fs';
-import { getDirectories, getFiles } from '../utils/file';
-import { promisify } from 'util';
+import { readFile } from 'fs/promises';
+import { exists, getDirectories, getFiles } from '../utils/file';
 import { I18nTranslation } from '../interfaces/i18n-translation.interface';
 import {
   Observable,
@@ -14,8 +13,6 @@ import {
 } from 'rxjs';
 import * as chokidar from 'chokidar';
 import { switchMap } from 'rxjs/operators';
-const readFile = promisify(fs.readFile);
-const exists = promisify(fs.exists);
 
 export interface I18nAbstractLoaderOptions {
   path: string;

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,10 +1,10 @@
-import * as fs from 'fs';
+import { readdir, lstat, stat } from 'fs/promises';
+import type { Dirent } from 'fs';
 import * as path from 'path';
-import { promisify } from 'util';
 
-const readdir = promisify(fs.readdir);
-const lstat = promisify(fs.lstat);
-const exists = promisify(fs.exists);
+export const exists = async (path: string): Promise<boolean> => {
+  return !!(await stat(path));
+};
 
 export function mapAsync<T, U>(
   array: T[],
@@ -36,7 +36,7 @@ export const getFiles = async (dirPath: string, pattern: RegExp) => {
   const dirs = await readdir(dirPath, { withFileTypes: true });
 
   return (
-    await filterAsync(dirs, async (f: fs.Dirent | string) => {
+    await filterAsync(dirs, async (f: Dirent | string) => {
       try {
         if (typeof f === 'string') {
           return (await exists(path.join(dirPath, f))) && pattern.test(f);


### PR DESCRIPTION
Consider using `fs/promises` instead of the older `fs` module.
That way, we don't need to `promisify` its methods.

Documentation: https://nodejs.org/api/fs.html#promises-api