### PR TITLE
add option to change http code in I18nValidationExceptionFilter

### DIFF
--- a/docs/guides/dto-validation.md
+++ b/docs/guides/dto-validation.md
@@ -5,13 +5,14 @@ sidebar_position: 7
 # DTO Validation
 
 To use `nestjs-i18n` in your DTO validation you first need to follow the [**nestjs instructions**](https://docs.nestjs.com/techniques/validation). After that you need to use the `i18nValidationErrorFactory` function in your `ValidationPipe`.
+
 ```typescript title="src/main.ts"
 import { i18nValidationErrorFactory } from 'nestjs-i18n';
 
 app.useGlobalPipes(
-    new ValidationPipe({
-        exceptionFactory: i18nValidationErrorFactory,
-    }),
+  new ValidationPipe({
+    exceptionFactory: i18nValidationErrorFactory,
+  }),
 );
 ```
 
@@ -74,11 +75,11 @@ Inside your translation you now can use `class-validator` properties such as `pr
 
 ```json title="src/i18n/en/validation.json"
 {
-    "NOT_EMPTY": "{property} cannot be empty",
-    "INVALID_EMAIL": "email is invalid",
-    "INVALID_BOOLEAN": "{property} is not a boolean",
-    "MIN": "{property} with value: \"{value}\" needs to be at least {constraints.0}, ow and {message}",
-    "MAX": "{property} with value: \"{value}\" needs to be less than {constraints.0}, ow and {message}"
+  "NOT_EMPTY": "{property} cannot be empty",
+  "INVALID_EMAIL": "email is invalid",
+  "INVALID_BOOLEAN": "{property} is not a boolean",
+  "MIN": "{property} with value: \"{value}\" needs to be at least {constraints.0}, ow and {message}",
+  "MAX": "{property} with value: \"{value}\" needs to be less than {constraints.0}, ow and {message}"
 }
 ```
 
@@ -100,12 +101,21 @@ create(@Body() createUserDto: CreateUserDto): any {
 import { I18nValidationExceptionFilter } from 'nestjs-i18n';
 
 app.useGlobalFilters(new I18nValidationExceptionFilter());
-
 ```
+
+#### I18nValidationExceptionFilterOptions
+
+`I18nValidationExceptionFilter` also takes an argument of type `I18nValidationExceptionFilterOptions`
+
+| Name                  | Type                                    | Required | Default | Description                                                            |
+| --------------------- | --------------------------------------- | -------- | ------- | ---------------------------------------------------------------------- |
+| `detailedErrors`      | `boolean`                               | false    | `true`  | Simplify error messages                                                |
+| `errorFormatter`      | `(errors: ValidationError[]) => object` | false    |         | Return the validation errors in a format that you specify.             |
+| `errorHttpStatusCode` | `HttpStatus`                            | false    | `400`   | Change the default http status code for the `I18nValidationException`. |
+
 :::info
 
-`I18nValidationExceptionFilter` also takes an argument of type `I18nValidationExceptionFilterOptions` for simplifying error messages.
-`new I18nValidationExceptionFilter({detailedErrors: false})` will return the simplified error message. `new I18nValidationExceptionFilter({errorFormatter: /* your custom error formatter function */ })` will return the validation errors in a format that you specify. Note that only one of the properties can be used at the time.
+Note that only one of the properties `detailedErrors` and `errorFormatter` can be used at the time.
 
 :::
 
@@ -115,49 +125,49 @@ Now your validation errors are being translated 🎉!
 
 ```json title="response"
 {
-    "statusCode": 400,
-    "errors": [
-      {
-        "property": "email",
-        "children": [],
-        "constraints": {
-          "isEmail": "email is invalid",
-          "isNotEmpty": "email cannot be empty",
+  "statusCode": 400,
+  "errors": [
+    {
+      "property": "email",
+      "children": [],
+      "constraints": {
+        "isEmail": "email is invalid",
+        "isNotEmpty": "email cannot be empty"
+      }
+    },
+    {
+      "property": "password",
+      "children": [],
+      "constraints": { "isNotEmpty": "password cannot be empty" }
+    },
+    {
+      "property": "extra",
+      "children": [
+        {
+          "property": "subscribeToEmail",
+          "children": [],
+          "constraints": {
+            "isBoolean": "subscribeToEmail is not a boolean"
+          }
         },
-      },
-      {
-        "property": "password",
-        "children": [],
-        "constraints": { "isNotEmpty": "password cannot be empty" },
-      },
-      {
-        "property": "extra",
-        "children": [
-          {
-            "property": "subscribeToEmail",
-            "children": [],
-            "constraints": {
-              "isBoolean": "subscribeToEmail is not a boolean",
-            },
-          },
-          {
-            "property": "min",
-            "children": [],
-            "constraints": {
-              "min": "min with value: \"1\" needs to be at least 5, ow and COOL",
-            },
-          },
-          {
-            "property": "max",
-            "children": [],
-            "constraints": {
-              "max": "max with value: \"100\" needs to be less than 10, ow and SUPER",
-            },
-          },
-        ],
-        "constraints": {},
-      },
-    ]
+        {
+          "property": "min",
+          "children": [],
+          "constraints": {
+            "min": "min with value: \"1\" needs to be at least 5, ow and COOL"
+          }
+        },
+        {
+          "property": "max",
+          "children": [],
+          "constraints": {
+            "max": "max with value: \"100\" needs to be less than 10, ow and SUPER"
+          }
+        }
+      ],
+      "constraints": {}
+    }
+  ]
 }
 ```
 

--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -5,17 +5,17 @@ import {
   ValidationError,
 } from '@nestjs/common';
 import iterate from 'iterare';
+import { I18nContext } from '../i18n.context';
+import {
+  I18nValidationError,
+  I18nValidationException,
+} from '../interfaces/i18n-validation-error.interface';
 import {
   I18nValidationExceptionFilterDetailedErrorsOption,
   I18nValidationExceptionFilterErrorFormatterOption,
 } from '../interfaces/i18n-validation-exception-filter.interface';
 import { Either } from '../types/either.type';
 import { mapChildrenToValidationErrors } from '../utils/format';
-import { I18nContext } from '../i18n.context';
-import {
-  I18nValidationError,
-  I18nValidationException,
-} from '../interfaces/i18n-validation-error.interface';
 import { getI18nContextFromArgumentsHost } from '../utils/util';
 
 type I18nValidationExceptionFilterOptions = Either<
@@ -38,11 +38,14 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
     switch (host.getType() as string) {
       case 'http':
         const response = host.switchToHttp().getResponse();
-        response.status(exception.getStatus()).send({
-          statusCode: exception.getStatus(),
-          message: exception.getResponse(),
-          errors: this.normalizeValidationErrors(errors),
-        });
+        response
+          .status(this.options.errorHttpStatusCode || exception.getStatus())
+          .send({
+            statusCode:
+              this.options.errorHttpStatusCode || exception.getStatus(),
+            message: exception.getResponse(),
+            errors: this.normalizeValidationErrors(errors),
+          });
         break;
       case 'graphql':
         exception.errors = this.normalizeValidationErrors(

--- a/src/interfaces/i18n-validation-exception-filter.interface.ts
+++ b/src/interfaces/i18n-validation-exception-filter.interface.ts
@@ -1,7 +1,8 @@
-import { ValidationError } from '@nestjs/common';
+import { HttpStatus, ValidationError } from '@nestjs/common';
 
 export interface I18nValidationExceptionFilterDetailedErrorsOption {
   detailedErrors?: boolean;
+  errorHttpStatusCode?: HttpStatus;
 }
 
 export interface I18nValidationExceptionFilterErrorFormatterOption {

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -8,6 +8,7 @@ import {
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
+import { GrpcMethod, Payload } from '@nestjs/microservices';
 import {
   I18n,
   I18nContext,
@@ -17,11 +18,10 @@ import {
 } from '../../../src';
 import { I18nRequestScopeService } from '../../../src/services/i18n-request-scope.service';
 import { CreateUserDto } from '../dto/create-user.dto';
+import { exampleErrorFormatter } from '../examples/example.functions';
 import { TestException, TestExceptionFilter } from '../filter/test.filter';
 import { TestGuard } from '../guards/test.guard';
-import { GrpcMethod, Payload } from '@nestjs/microservices';
 import { Hero, HeroById } from '../interfaces/hero.interface';
-import { exampleErrorFormatter } from '../examples/example.functions';
 
 @Controller('hello')
 @UseFilters(new TestExceptionFilter())
@@ -159,6 +159,12 @@ export class HelloController {
   @Post('/validation-without-details')
   @UseFilters(new I18nValidationExceptionFilter({ detailedErrors: false }))
   validationWithoutDetails(@Body() createUserDto: CreateUserDto): any {
+    return 'This action adds a new user';
+  }
+
+  @Post('/validation-with-custom-http-code')
+  @UseFilters(new I18nValidationExceptionFilter({ errorHttpStatusCode: 422 }))
+  validationWithCustomHttpCode(@Body() createUserDto: CreateUserDto): any {
     return 'This action adds a new user';
   }
 

--- a/tests/i18n-dto.e2e.spec.ts
+++ b/tests/i18n-dto.e2e.spec.ts
@@ -1,17 +1,17 @@
+import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
 import * as path from 'path';
+import * as request from 'supertest';
 import {
+  AcceptLanguageResolver,
   CookieResolver,
   HeaderResolver,
-  AcceptLanguageResolver,
   I18nModule,
   QueryResolver,
 } from '../src';
-import * as request from 'supertest';
-import { HelloController } from './app/controllers/hello.controller';
-import { NestExpressApplication } from '@nestjs/platform-express';
-import { ValidationPipe } from '@nestjs/common';
 import { i18nValidationErrorFactory } from '../src/utils/util';
+import { HelloController } from './app/controllers/hello.controller';
 
 describe('i18n module e2e dto', () => {
   let app: NestExpressApplication;
@@ -454,6 +454,32 @@ describe('i18n module e2e dto', () => {
           message: 'Bad Request',
           errors: [
             'email is invalid',
+            'password cannot be empty',
+            'extra.subscribeToEmail is not a boolean',
+            'extra.min with value: "1" needs to be at least 5, ow and COOL',
+            'extra.max with value: "100" needs to be less than 10, ow and SUPER',
+          ],
+        });
+      });
+  });
+
+  it(`should translate validation messages with custom http code`, async () => {
+    await request(app.getHttpServer())
+      .post('/hello/validation-with-custom-http-code')
+      .send({
+        email: '',
+        password: '',
+        extra: { subscribeToEmail: '', min: 1, max: 100 },
+      })
+      .set('Accept', 'application/json')
+      .expect(422)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          statusCode: 422,
+          message: 'Bad Request',
+          errors: [
+            'email is invalid',
+            'email cannot be empty',
             'password cannot be empty',
             'extra.subscribeToEmail is not a boolean',
             'extra.min with value: "1" needs to be at least 5, ow and COOL',


### PR DESCRIPTION
The `i18nValidationErrorFactory` always returns a `I18nValidationExceptionFilter` with 400 as http code.
It could be useful to change it (422 for example)