### PR TITLE
refactor (i18n-service): remove unnecessary args check

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -165,7 +165,7 @@ export class I18nService {
 
     let translation = translations[key] ?? options?.defaultValue;
 
-    if (translation && (args || (args instanceof Array && args.length > 0))) {
+    if (translation) {
       const pluralObject = this.getPluralObject(translation);
       if (pluralObject && args && args['count'] !== undefined) {
         const count = Number(args['count']);
@@ -252,7 +252,7 @@ export class I18nService {
     const list = [];
     const regex = /\$t\((.*?)(,(.*?))?\)/g;
     let result: RegExpExecArray;
-    while ((result = regex.exec(translation))) {
+    while (result = regex.exec(translation)) {
       let key = undefined;
       let args = {};
       let index = undefined;


### PR DESCRIPTION
- we already have `const args = options?.args ?? {};` in line 151 so `(args || (args instanceof Array && args.length > 0)))` is always evaluated to true
- remove unnecessary extra parenthesis in while loop