### PR TITLE
Fix memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
+    "prepare":"npm run build",
     "build": "npm run build:lib",
-    "build:lib": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build:lib": "npx rimraf dist && tsc -p tsconfig.build.json",
     "prepublish:npm": "npm run build",
     "publish:npm": "npm publish --access public",
     "prepublish:next": "npm run build",


### PR DESCRIPTION
The library seems to leak memory due to missing unsubscribes in the i18n service.  

### Context
I am using nestjs-i18n in a [bull](https://github.com/nestjs/bull) queue task, that runs quite often and in a [separate process](https://docs.nestjs.com/techniques/queues#separate-processes). 
Since version nestjs-i18n 9.0.0 our server restarts often because we run out of memory. 

Before fix:
<img width="601" alt="memory leaks i18n" src="https://user-images.githubusercontent.com/13244204/184893676-9e4bb001-8dd7-4d17-bff7-4f19cd76a556.png">

Before nestjs-i18n 9.0.0 version:
<img width="594" alt="memory leaks i18n without" src="https://user-images.githubusercontent.com/13244204/184893699-0c9acaac-a90c-48a8-9fdd-6ec57451fa2f.png">

After fix:
<img width="463" alt="memory leaks i18n after" src="https://user-images.githubusercontent.com/13244204/184893725-b0122859-0f5e-4b41-a20e-f8cae70d5b6f.png">

