### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,10 @@ tsconfig.json
 .prettierrc
 .idea
 tests
+docs
+static
+sidebars.js
+docusaurus.config.js
+.github
+.eslintrc.js
+babel.config.js


### PR DESCRIPTION
removes unwanted files from published package
The current package size is  `3.9MB` . After inspecting , I found some files that are not needed in the final library build are also exported on the package.
![](https://i.imgur.com/iVH8vZQ.png)

After removing the unwanted files like docs and static assets, the library size goes down to `85KB` which is a great reduction in size