### PR TITLE
Fix for RangeError: Maximum call stack size exceeded

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -81,6 +81,8 @@ export class I18nService<K = Record<string, unknown>>
       return key as unknown as IfAnyOrNever<R, string, R>;
     }
 
+	const previousFallbackLang = lang;
+
     lang =
       lang === undefined || lang === null
         ? this.i18nOptions.fallbackLanguage
@@ -111,9 +113,15 @@ export class I18nService<K = Record<string, unknown>>
           this.logger.error(message);
         }
 
+		const nextFallbackLanguage = this.getFallbackLanguage(lang);
+
+		if (previousFallbackLang === nextFallbackLanguage) {
+		  return key as unknown as IfAnyOrNever<R, string, R>;
+		}
+
         return this.translate(key, {
           ...options,
-          lang: this.getFallbackLanguage(lang),
+          lang: nextFallbackLanguage,
         });
       }
     }

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -115,14 +115,12 @@ export class I18nService<K = Record<string, unknown>>
 
 		const nextFallbackLanguage = this.getFallbackLanguage(lang);
 
-		if (previousFallbackLang === nextFallbackLanguage) {
-		  return key as unknown as IfAnyOrNever<R, string, R>;
+		if (previousFallbackLang !== nextFallbackLanguage) {
+		  return this.translate(key, {
+		    ...options,
+		    lang: nextFallbackLanguage,
+		  });
 		}
-
-        return this.translate(key, {
-          ...options,
-          lang: nextFallbackLanguage,
-        });
       }
     }
 

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -28,8 +28,7 @@ export type TranslateOptions = {
 
 @Injectable()
 export class I18nService<K = Record<string, unknown>>
-  implements I18nTranslator<K>, OnModuleDestroy
-{
+  implements I18nTranslator<K>, OnModuleDestroy {
   private supportedLanguages: string[];
   private translations: I18nTranslation;
   private pluralRules = new Map<string, Intl.PluralRules>();
@@ -81,7 +80,7 @@ export class I18nService<K = Record<string, unknown>>
       return key as unknown as IfAnyOrNever<R, string, R>;
     }
 
-	const previousFallbackLang = lang;
+    const previousFallbackLang = lang;
 
     lang =
       lang === undefined || lang === null
@@ -107,20 +106,19 @@ export class I18nService<K = Record<string, unknown>>
     ) {
       if (lang !== this.i18nOptions.fallbackLanguage || !!defaultValue) {
         if (this.i18nOptions.logging) {
-          const message = `Translation "${
-            key as string
-          }" in "${lang}" does not exist.`;
+          const message = `Translation "${key as string
+            }" in "${lang}" does not exist.`;
           this.logger.error(message);
         }
 
-		const nextFallbackLanguage = this.getFallbackLanguage(lang);
+        const nextFallbackLanguage = this.getFallbackLanguage(lang);
 
-		if (previousFallbackLang !== nextFallbackLanguage) {
-		  return this.translate(key, {
-		    ...options,
-		    lang: nextFallbackLanguage,
-		  });
-		}
+        if (previousFallbackLang !== nextFallbackLanguage) {
+          return this.translate(key, {
+            ...options,
+            lang: nextFallbackLanguage,
+          });
+        }
       }
     }
 
@@ -263,14 +261,14 @@ export class I18nService<K = Record<string, unknown>>
         for (const nestedTranslation of nestedTranslations) {
           const result = rootTranslations
             ? (this.translateObject(
-                nestedTranslation.key,
-                rootTranslations,
-                lang,
-                {
-                  ...options,
-                  args: { parent: options.args, ...nestedTranslation.args },
-                },
-              ) as string) ?? ''
+              nestedTranslation.key,
+              rootTranslations,
+              lang,
+              {
+                ...options,
+                args: { parent: options.args, ...nestedTranslation.args },
+              },
+            ) as string) ?? ''
             : '';
           translation =
             translation.substring(0, nestedTranslation.index - offset) +

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -48,6 +48,10 @@ export class HelloController {
   @Render('index2')
   index2(): any {}
 
+  @Get('/index3')
+  @Render('index3')
+  index3(): any {}
+
   @Get('/short')
   helloShort(@I18nLang() lang: string): any {
     return this.i18n.t('test.HELLO', { lang });

--- a/tests/app/views/ejs/index3.ejs
+++ b/tests/app/views/ejs/index3.ejs
@@ -1,0 +1,1 @@
+<%= t('test.HI', i18nLang) -%>

--- a/tests/i18n-ejs.e2e.spec.ts
+++ b/tests/i18n-ejs.e2e.spec.ts
@@ -92,6 +92,23 @@ describe('i18n module e2e ejs', () => {
       .expect('Hallo');
   });
 
+  it(`should render page showing invalid key`, async () => {
+    await request(app.getHttpServer())
+      .get('/hello/index3')
+      .expect(200)
+      .expect('test.HI');
+	
+    await request(app.getHttpServer())
+	  .get('/hello/index3?l=pt')
+      .expect(200)
+      .expect('test.HI');
+	  
+	return request(app.getHttpServer())
+      .get('/hello/index3?l=pt-br')
+      .expect(200)
+      .expect('test.HI');
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/tests/i18n-ejs.e2e.spec.ts
+++ b/tests/i18n-ejs.e2e.spec.ts
@@ -23,7 +23,7 @@ import { Global, Module } from '@nestjs/common';
   ],
   exports: ['OPTIONS'],
 })
-export class OptionsModule {}
+export class OptionsModule { }
 
 describe('i18n module e2e ejs', () => {
   let app: NestExpressApplication;
@@ -97,13 +97,13 @@ describe('i18n module e2e ejs', () => {
       .get('/hello/index3')
       .expect(200)
       .expect('test.HI');
-	
+
     await request(app.getHttpServer())
-	  .get('/hello/index3?l=pt')
+      .get('/hello/index3?l=pt')
       .expect(200)
       .expect('test.HI');
-	  
-	return request(app.getHttpServer())
+
+    return request(app.getHttpServer())
       .get('/hello/index3?l=pt-br')
       .expect(200)
       .expect('test.HI');


### PR DESCRIPTION
# Description

Fix "RangeError: Maximum call stack size exceeded" when trying to translate a key that doesn't exist and Nestjs-i18n tries to use an unsupported fallback language.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Example

Using an invalid key for translation:

> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.
> [Nest] 20128  - 11/01/2023 07:51:52   ERROR [ExceptionsHandler] Maximum call stack size exceeded
> RangeError: Maximum call stack size exceeded
>     at writeOrBuffer (node:internal/streams/writable:368:23)
>     at _write (node:internal/streams/writable:333:10)
>     at WriteStream.Writable.write (node:internal/streams/writable:337:10)
>     at D:\web\website\static\node_modules\@nestjs\common\services\console-logger.service.js:122:106
>     at Array.forEach (<anonymous>)
>     at ConsoleLogger.printMessages (D:\web\website\static\node_modules\@nestjs\common\services\console-logger.service.js:116:18)
>     at ConsoleLogger.error (D:\web\website\static\node_modules\@nestjs\common\services\console-logger.service.js:43:14)
>     at Logger.error (D:\web\website\static\node_modules\@nestjs\common\services\logger.service.js:34:75)
>     at Logger.descriptor.value (D:\web\website\static\node_modules\@nestjs\common\services\logger.service.js:163:27)
>     at I18nService.translate (D:\web\website\static\node_modules\nestjs-i18n\src\services\i18n.service.ts:115:23)

The **Supported Languages** ​​I'm using are [ 'en', 'es', 'pt-br'], but the Nestjs-i18n was trying to revert to 'pt' creating an infinite loop in the **translate** function because:

Line 116: 
```
lang: this.getFallbackLanguage(lang),
// lang = 'pt'
```

Line 89:
```
lang = this.resolveLanguage(lang);
// lang = 'pt-br'
```

There is now a check if the fallback language has already been used:

```
if (previousFallbackLang === nextFallbackLanguage) {
  return key as unknown as IfAnyOrNever<R, string, R>;
}
```

Nestjs-i18n log now:

> 
> [Nest] 17556  - 11/01/2023 21:17:48     LOG [NestApplication] Nest application successfully started +11ms
> [Nest] 17556  - 11/01/2023 21:17:51   ERROR [I18nService] Translation "route.null" in "pt-br" does not exist.
> [Nest] 17556  - 11/01/2023 21:17:51   ERROR [I18nService] Translation "route.null" in "pt-BR" does not exist.

