### PR TITLE
fix: typo in warning message

### DIFF
--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -399,7 +399,7 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
   private static createResolverProviders(resolvers?: I18nOptionResolver[]) {
     if (!resolvers || resolvers.length === 0) {
       logger.error(
-        `No resolvers provided! nestjs-i18n won't workt properly, please follow the quick-start guide: https://nestjs-i18n.com/quick-start`,
+        `No resolvers provided! nestjs-i18n won't work properly, please follow the quick-start guide: https://nestjs-i18n.com/quick-start`,
       );
     }
     return (resolvers || [])


### PR DESCRIPTION
Fixes a typo in the warning message. The warning message shows when to resolvers are defined.