### PR TITLE
fix: I18nContext.current() undefined when using additional interceptors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-i18n",
-  "version": "10.3.6",
+  "version": "10.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-i18n",
-      "version": "10.3.6",
+      "version": "10.3.7",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",

--- a/src/interceptors/i18n-language.interceptor.ts
+++ b/src/interceptors/i18n-language.interceptor.ts
@@ -71,11 +71,13 @@ export class I18nLanguageInterceptor implements NestInterceptor {
       ctx.i18nContext = new I18nContext(ctx.i18nLang, this.i18nService);
 
       if (!this.i18nOptions.skipAsyncHook) {
-        return I18nContext.createAsync(ctx.i18nContext, async (error) => {
-          if (error) {
-            throw error;
-          }
-          return next.handle();
+        return new Observable((observer) => {
+          I18nContext.createAsync(ctx.i18nContext, async (error) => {
+            if (error) {
+              throw error;
+            }
+            return next.handle().subscribe(observer);
+          });
         });
       }
     }

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -7,6 +7,7 @@ import {
   Render,
   UseFilters,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { GrpcMethod, Payload } from '@nestjs/microservices';
 import {
@@ -21,7 +22,8 @@ import { CreateUserDto } from '../dto/create-user.dto';
 import { TestException, TestExceptionFilter } from '../filter/test.filter';
 import { TestGuard } from '../guards/test.guard';
 import { Hero, HeroById } from '../interfaces/hero.interface';
-import {exampleErrorFormatter, exampleResponseBodyFormatter} from '../examples/example.functions';
+import { exampleErrorFormatter, exampleResponseBodyFormatter } from '../examples/example.functions';
+import { TestInterceptor } from '../interceptors/test.interceptor';
 
 @Controller('hello')
 @UseFilters(new TestExceptionFilter())
@@ -84,6 +86,12 @@ export class HelloController {
 
   @Get('/request-scope')
   helloRequestScope(): any {
+    return I18nContext.current<I18nTranslations>().translate('test.HELLO');
+  }
+
+  @Get('/request-scope/additional-interceptor')
+  @UseInterceptors(TestInterceptor)
+  helloRequestScopeAdditionalInterceptor(): any {
     return I18nContext.current<I18nTranslations>().translate('test.HELLO');
   }
 
@@ -189,10 +197,10 @@ export class HelloController {
 
   @Post('/validation-custom-response-body-formatter')
   @UseFilters(
-      new I18nValidationExceptionFilter({
-        responseBodyFormatter: exampleResponseBodyFormatter,
-        errorFormatter: exampleErrorFormatter,
-      }),
+    new I18nValidationExceptionFilter({
+      responseBodyFormatter: exampleResponseBodyFormatter,
+      errorFormatter: exampleErrorFormatter,
+    }),
   )
   validationResponseBodyFormatter(@Body() createUserDto: CreateUserDto): any {
     return 'This action adds a new user';

--- a/tests/app/interceptors/test.interceptor.ts
+++ b/tests/app/interceptors/test.interceptor.ts
@@ -1,0 +1,14 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class TestInterceptor implements NestInterceptor {
+  intercept(_: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle();
+  }
+}

--- a/tests/i18n-disable-middleware.e2e.spec.ts
+++ b/tests/i18n-disable-middleware.e2e.spec.ts
@@ -43,6 +43,14 @@ describe('i18n module e2e no middleware', () => {
     await request(app.getHttpServer()).get('/hello/guard?lang=nl').expect(500);
   });
 
+  it(`/GET hello/request-scope/additional-interceptor should return translation`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/request-scope/additional-interceptor')
+      .set('accept-language', 'fr-FR')
+      .expect(200)
+      .expect('Bonjour');
+  });
+
   afterAll(async () => {
     await app.close();
   });


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I discovered a bug when using `disableMiddleware: true`.
When relying on `I18nLanguageInterceptor` to initialize the `I18nContext`, it's not possible to use another interceptor on the same endpoint. 
When doing so, the `AsyncLocalStorage` containing the i18n context is broken: `I18nContext.current()` always returns `undefined`.

### How to reproduce

- Set `disableMiddleware: true` in `I18nModule` options.
- Define a simple interceptor such as:
```ts
@Injectable()
export class TestInterceptor implements NestInterceptor {
  intercept(_: ExecutionContext, next: CallHandler): Observable<unknown> {
    return next.handle();
  }
}
```

- Add it on your endpoint:
```ts
@Get()
@UseInterceptors(TestInterceptor)
helloWorld() {
  return I18nContext.current()?.lang;
}
```

- This endpoint will always return `undefined` instead of the resolved lang. When removing the interceptor it works.

### Additional context

I did something similar to the `nestjs-cls`'s interceptor implementation: https://github.com/Papooch/nestjs-cls/blob/main/packages/core/src/lib/cls-initializers/cls.interceptor.ts
I just simplified it by passing the observer directly to the `subscribe` method.
I added a test in `i18n-disable-middleware.e2e.spec.ts` to avoid regressions.

See also:
- https://stackoverflow.com/questions/67136005/how-to-use-asynclocalstorage-for-an-observable
