### PR TITLE
move error log to only show if key for default value is missing

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -88,10 +88,7 @@ export class I18nService<K = Record<string, unknown>>
 
     const previousFallbackLang = lang;
 
-    lang =
-      lang === undefined || lang === null
-        ? this.i18nOptions.fallbackLanguage
-        : lang;
+    lang = lang ?? this.i18nOptions.fallbackLanguage;
 
     lang = this.resolveLanguage(lang);
 
@@ -99,26 +96,19 @@ export class I18nService<K = Record<string, unknown>>
 
     const translation = this.translateObject(
       key as string,
-      (translationsByLanguage ? translationsByLanguage : key) as string,
+      (translationsByLanguage ?? key) as string,
       lang,
       options,
-      translationsByLanguage ? translationsByLanguage : undefined,
+      translationsByLanguage,
     );
 
-    if (
-      translationsByLanguage === undefined ||
-      translationsByLanguage === null ||
-      !translation
-    ) {
+    if (translationsByLanguage == null || !translation) {
+      const translationKeyMissing = `Translation "${
+        key as string
+      }" in "${lang}" does not exist.`;
       if (lang !== this.i18nOptions.fallbackLanguage || !!defaultValue) {
-        if (this.i18nOptions.logging) {
-          const message = `Translation "${
-            key as string
-          }" in "${lang}" does not exist.`;
-          this.logger.error(message);
-          if (this.i18nOptions.throwOnMissingKey) {
-            throw new I18nError(message);
-          }
+        if (this.i18nOptions.logging && this.i18nOptions.throwOnMissingKey) {
+          throw new I18nError(translationKeyMissing);
         }
 
         const nextFallbackLanguage = this.getFallbackLanguage(lang);
@@ -130,6 +120,8 @@ export class I18nService<K = Record<string, unknown>>
           });
         }
       }
+
+      this.logger.error(translationKeyMissing);
     }
 
     return (translation ?? key) as unknown as IfAnyOrNever<R, string, R>;


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

As discussed here [https://github.com/toonvanstrijp/nestjs-i18n/discussions/540](https://github.com/toonvanstrijp/nestjs-i18n/discussions/540): It would be nice to only print an error to the console if the translation couldn't be found in any fallback language. Therefore I created this PR.

This will prevent "polluting" logs as the system works as intended and will only log an error if no key in any fallback language is found.

### Linked Issues
[https://github.com/toonvanstrijp/nestjs-i18n/discussions/540](https://github.com/toonvanstrijp/nestjs-i18n/discussions/540)

### Additional context

Following the Boy Scout rule (Always leave the code you are working on a little bit better than you found it.) I also tried to make the function I touched more readable.

This is my first contribution. Feel free to remark on anything I can improve. :relieved: