### PR TITLE
Adding some missing path. to code quick-start.mdx examples

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -129,7 +129,7 @@ import { I18nModule, AcceptLanguageResolver, QueryResolver, HeaderResolver } fro
       useFactory: (configService: ConfigService) => ({
         fallbackLanguage: configService.getOrThrow('FALLBACK_LANGUAGE'),
         loaderOptions: {
-          path: join(__dirname, '/i18n/'),
+          path: path.join(__dirname, '/i18n/'),
           watch: true,
         },
       }),
@@ -275,7 +275,7 @@ import {
       useFactory: (configService: ConfigService) => ({
         fallbackLanguage: "en",
         loaderOptions: {
-          path: join(__dirname, "/i18n/"),
+          path: path.join(__dirname, "/i18n/"),
           watch: true,
         },
       }),


### PR DESCRIPTION
Fixing missing ``path.`` to the ``path.join`` of some quick-start code examples

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Some code examples of the quickstart guide miss the `path.` before the join, when concatenating the current directory with the i18n module. This PR just adds those missing `path.`.

### Linked Issues


### Additional context

