### PR TITLE
Use context lang as primary default for service

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -326,10 +326,15 @@ import { I18nContext, I18nService } from 'nestjs-i18n';
 export class AppService {
   constructor(private readonly i18n: I18nService) {}
   getHello(): string {
-    return this.i18n.t('test.HELLO',{ lang:   I18nContext.current().lang });
+    return this.i18n.t('test.HELLO');
+  }
+
+  getHelloInSpecificLanguage(): string {
+    return this.i18n.t('test.HELLO',{ lang: "en" });
   }
 }
 ```
+
 
 ## Translate options
 

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -8,7 +8,12 @@ import {
   take,
   takeUntil,
 } from 'rxjs';
-import { I18nOptions, I18nTranslation, I18nValidationError } from '..';
+import {
+  I18nContext,
+  I18nOptions,
+  I18nTranslation,
+  I18nValidationError,
+} from '..';
 import {
   I18N_LANGUAGES,
   I18N_LANGUAGES_SUBJECT,
@@ -75,7 +80,7 @@ export class I18nService<K = Record<string, unknown>>
     options?: TranslateOptions,
   ): IfAnyOrNever<R, string, R> {
     options = {
-      lang: this.i18nOptions.fallbackLanguage,
+      lang: I18nContext.current()?.lang || this.i18nOptions.fallbackLanguage,
       ...options,
     };
 

--- a/tests/app/cats/cat.resolver.ts
+++ b/tests/app/cats/cat.resolver.ts
@@ -39,6 +39,14 @@ export class CatResolver {
     return cat;
   }
 
+  @Query('catUsingService')
+  async getCatUsingService(@Args('id') id: number) {
+    const cat = await this.catService.findById(id);
+    // we manually overwrite this property to indicate a value that is translated!
+    cat.description = this.i18nService.translate('test.cat');
+    return cat;
+  }
+
   @Mutation('createCat')
   async create(@Args('createCatInput') args: CreateCatInput): Promise<any> {
     await this.pubSub.publish('catAdded', { catAdded: args.name });

--- a/tests/app/cats/cat.types.graphql
+++ b/tests/app/cats/cat.types.graphql
@@ -9,6 +9,7 @@ type Query {
   cats: [Cat]
   cat(id: Int!): Cat
   catUsingContext(id: Int!): Cat
+  catUsingService(id: Int!): Cat
 }
 
 type Mutation {

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -35,6 +35,11 @@ export class HelloController {
     return this.i18n.translate('test.HELLO', { lang });
   }
 
+  @Get('/no-lang-for-service')
+  helloNoLangForService(): any {
+    return this.i18n.translate('test.HELLO');
+  }
+
   @Get('/typed')
   helloTyped(@I18nLang() lang: string): string {
     return this.i18n.translate('test.HELLO', { lang });
@@ -57,6 +62,11 @@ export class HelloController {
   @Get('/short')
   helloShort(@I18nLang() lang: string): any {
     return this.i18n.t('test.HELLO', { lang });
+  }
+
+  @Get('/short/no-lang-for-service')
+  helloShortNoLangForService(): any {
+    return this.i18n.t('test.HELLO');
   }
 
   @Get('/short/typed')

--- a/tests/app/controllers/hello.controller.ts
+++ b/tests/app/controllers/hello.controller.ts
@@ -22,7 +22,10 @@ import { CreateUserDto } from '../dto/create-user.dto';
 import { TestException, TestExceptionFilter } from '../filter/test.filter';
 import { TestGuard } from '../guards/test.guard';
 import { Hero, HeroById } from '../interfaces/hero.interface';
-import { exampleErrorFormatter, exampleResponseBodyFormatter } from '../examples/example.functions';
+import {
+  exampleErrorFormatter,
+  exampleResponseBodyFormatter,
+} from '../examples/example.functions';
 import { TestInterceptor } from '../interceptors/test.interceptor';
 
 @Controller('hello')
@@ -231,6 +234,20 @@ export class HelloController {
       {
         id: 1,
         name: i18n.t('test.set-up-password.heading', {
+          args: { username: 'John' },
+        }),
+      },
+      { id: 2, name: 'Doe' },
+    ];
+    return items.find(({ id }) => id === data.id);
+  }
+
+  @GrpcMethod('HeroesService', 'FindOneTranslatedWithService')
+  findOneTranslatedWithService(@Payload() data: HeroById): Hero {
+    const items = [
+      {
+        id: 1,
+        name: this.i18n.t('test.set-up-password.heading', {
           args: { username: 'John' },
         }),
       },

--- a/tests/app/hero.proto
+++ b/tests/app/hero.proto
@@ -4,6 +4,7 @@ package hero;
 
 service HeroesService {
   rpc FindOne (HeroById) returns (Hero) {}
+  rpc FindOneTranslatedWithService (HeroById) returns (Hero) {}
 }
 
 message HeroById {

--- a/tests/app/interfaces/hero.interface.ts
+++ b/tests/app/interfaces/hero.interface.ts
@@ -12,4 +12,8 @@ export interface HeroById {
 
 export interface HeroService {
   findOne(data: HeroById, metadata: Metadata): Observable<Hero>;
+  findOneTranslatedWithService(
+    data: HeroById,
+    metadata: Metadata,
+  ): Observable<Hero>;
 }

--- a/tests/i18n-express.e2e.spec.ts
+++ b/tests/i18n-express.e2e.spec.ts
@@ -617,6 +617,82 @@ describe('i18n module e2e express', () => {
       .expect({ lang: 'nl' });
   });
 
+  it(`/GET hello/no-lang-for-service should return fallback language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .expect(200)
+      .expect('Hello');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing query resolver`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service?lang=nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing x-custom-lang`, () => {
+    return request(app.getHttpServer())
+    .get('/hello/no-lang-for-service')
+      .set('x-custom-lang', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing accept-language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .set('accept-language', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing cookie`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .set('Cookie', ['lang=nl'])
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return fallback language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .expect(200)
+      .expect('Hello');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing query resolver`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service?lang=nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing x-custom-lang`, () => {
+    return request(app.getHttpServer())
+    .get('/hello/short/no-lang-for-service')
+      .set('x-custom-lang', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing accept-language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .set('accept-language', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing cookie`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .set('Cookie', ['lang=nl'])
+      .expect(200)
+      .expect('Hallo');
+  });
+
   it('/POST cats with age 2 should error', async () => {
     await request(app.getHttpServer())
       .post('/cats')

--- a/tests/i18n-fastify.e2e.spec.ts
+++ b/tests/i18n-fastify.e2e.spec.ts
@@ -621,6 +621,82 @@ describe('i18n module e2e fastify', () => {
       .expect({ lang: 'nl' });
   });
 
+  it(`/GET hello/no-lang-for-service should return fallback language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .expect(200)
+      .expect('Hello');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing query resolver`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service?lang=nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing x-custom-lang`, () => {
+    return request(app.getHttpServer())
+    .get('/hello/no-lang-for-service')
+      .set('x-custom-lang', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing accept-language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .set('accept-language', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/no-lang-for-service should return translation when providing cookie`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/no-lang-for-service')
+      .set('Cookie', ['lang=nl'])
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return fallback language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .expect(200)
+      .expect('Hello');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing query resolver`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service?lang=nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing x-custom-lang`, () => {
+    return request(app.getHttpServer())
+    .get('/hello/short/no-lang-for-service')
+      .set('x-custom-lang', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing accept-language`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .set('accept-language', 'nl')
+      .expect(200)
+      .expect('Hallo');
+  });
+
+  it(`/GET hello/short/no-lang-for-service should return translation when providing cookie`, () => {
+    return request(app.getHttpServer())
+      .get('/hello/short/no-lang-for-service')
+      .set('Cookie', ['lang=nl'])
+      .expect(200)
+      .expect('Hallo');
+  });
+  
   it('/POST cats with age 2 should error', async () => {
     await request(app.getHttpServer())
       .post('/cats')

--- a/tests/i18n-gql.e2e.spec.ts
+++ b/tests/i18n-gql.e2e.spec.ts
@@ -464,6 +464,89 @@ describe('i18n module e2e graphql', () => {
       });
   });
 
+  it(`should query a particular cat (using injected I18nService) in fallback language`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{catUsingService(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          catUsingService: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Cat',
+          },
+        },
+      });
+  });
+
+  it(`should query a particular cat (using injected I18nService) in NL with x-custom-lang header`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('x-custom-lang', 'nl')
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{catUsingService(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          catUsingService: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Kat',
+          },
+        },
+      });
+  });
+
+  it(`should query a particular cat (using injected I18nService) in NL with cookie`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('Cookie', ['lang=nl'])
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{catUsingService(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          catUsingService: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Kat',
+          },
+        },
+      });
+  });
+
+  it(`should query a particular cat (using injected I18nService) in NL with accept-language header`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .set('accept-language', 'nl')
+      .send({
+        operationName: null,
+        variables: {},
+        query: '{catUsingService(id:2){id,name,age,description}}',
+      })
+      .expect(200, {
+        data: {
+          catUsingService: {
+            id: 2,
+            name: 'bar',
+            age: 6,
+            description: 'Kat',
+          },
+        },
+      });
+  });
+
   afterAll(async () => {
     apollo.stop();
     await subscriptionClient.dispose();

--- a/tests/i18n-rpc.e2e.spec.ts
+++ b/tests/i18n-rpc.e2e.spec.ts
@@ -89,6 +89,20 @@ describe('i18n module e2e rpc', () => {
     });
   });
 
+  it(`should translate grpc call with service`, async () => {
+    const meta = new Metadata();
+    meta.set('lang', 'fr');
+
+    await new Promise<void>((resolve) => {
+      heroService
+        .findOneTranslatedWithService({ id: 1 }, meta)
+        .subscribe((hero) => {
+          expect(hero).toEqual({ id: 1, name: 'Bonjour, John' });
+          resolve();
+        });
+    });
+  });
+
   afterAll(async () => {
     await app.close();
   });


### PR DESCRIPTION
When using I18nService, if the context lang is not passed to the service options, it will always fallback to the fallback language, even though the context lang is accessible automatically in I18nService.

So in order to prevent passing the lang manually to the I18nService options, I used the `I18nContext.current().lang` which is the lang resolved by resolvers, as the primary default for the translate method inside I18nService. 

If the context current lang does not exist, it will use the fallback lang as default.