### PR TITLE
fix(#646): I18nValidationExceptionFilter error response body

### DIFF
--- a/src/filters/i18n-validation-exception.filter.ts
+++ b/src/filters/i18n-validation-exception.filter.ts
@@ -90,18 +90,18 @@ export class I18nValidationExceptionFilter implements ExceptionFilter {
   protected buildResponseBody(
     host: ArgumentsHost,
     exc: I18nValidationException,
-    errors: string[] | I18nValidationError[] | object,
+    error: string[] | I18nValidationError[] | object,
   ) {
     if ('responseBodyFormatter' in this.options) {
-      return this.options.responseBodyFormatter(host, exc, errors);
+      return this.options.responseBodyFormatter(host, exc, error);
     } else {
       return {
         statusCode:
           this.options.errorHttpStatusCode === undefined
             ? exc.getStatus()
             : this.options.errorHttpStatusCode,
-        message: exc.getResponse(),
-        errors,
+        message: error,
+        error: exc.getResponse(),
       };
     }
   }

--- a/src/middlewares/i18n.middleware.ts
+++ b/src/middlewares/i18n.middleware.ts
@@ -92,7 +92,11 @@ export class I18nMiddleware implements NestMiddleware {
 class MiddlewareHttpContext
   implements ExecutionContext, ArgumentsHost, HttpArgumentsHost
 {
-  constructor(private req: any, private res: any, private next: any) {}
+  constructor(
+    private req: any,
+    private res: any,
+    private next: any,
+  ) {}
 
   getClass<T = any>(): Type<T> {
     throw ExecutionContextMethodNotImplemented;

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -42,7 +42,7 @@ export const convertObjectToTypeDefinition = async (
   return [];
 };
 
-const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed, });
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
 export const createTypesFile = async (object: any) => {
   const sourceFile = ts.createSourceFile(

--- a/tests/i18n-dto.e2e.spec.ts
+++ b/tests/i18n-dto.e2e.spec.ts
@@ -51,7 +51,7 @@ describe('i18n module e2e dto', () => {
 
   var toon = {
     statusCode: 400,
-    errors: [
+    message: [
       {
         property: 'email',
         children: [],
@@ -108,8 +108,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: {
+          message: {
             email: ['email is invalid', 'email cannot be empty'],
             password: ['password cannot be empty'],
             subscribeToEmail: ['extra.subscribeToEmail is not a boolean'],
@@ -120,6 +119,7 @@ describe('i18n module e2e dto', () => {
               'extra.max with value: "100" needs to be less than 10, ow and SUPER',
             ],
           },
+          error: 'Bad Request',
         });
       });
 
@@ -136,8 +136,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: {
+          message: {
             test: ['property test should not exist'],
             email: ['email is invalid', 'email cannot be empty'],
             password: ['password cannot be empty'],
@@ -149,6 +148,7 @@ describe('i18n module e2e dto', () => {
               'extra.max with value: "100" needs to be less than 10, ow and SUPER',
             ],
           },
+          error: 'Bad Request',
         });
       });
 
@@ -164,8 +164,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: {
+          message: {
             email: ['email is ongeldig', 'e-mail adres mag niet leeg zijn'],
             password: ['wachtwoord mag niet leeg zijn'],
             subscribeToEmail: ['extra.subscribeToEmail is geen boolean'],
@@ -176,6 +175,7 @@ describe('i18n module e2e dto', () => {
               'extra.max met waarde: "100" moet lager zijn dan 10, ow en SUPER',
             ],
           },
+          error: 'Bad Request',
         });
       });
   });
@@ -193,8 +193,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: [
+          message: [
             'email is invalid',
             'email cannot be empty',
             'password cannot be empty',
@@ -202,6 +201,7 @@ describe('i18n module e2e dto', () => {
             'extra.min with value: "1" needs to be at least 5, ow and COOL',
             'extra.max with value: "100" needs to be less than 10, ow and SUPER',
           ],
+          error: 'Bad Request',
         });
       });
 
@@ -218,8 +218,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: [
+          message: [
             'property test should not exist',
             'email is invalid',
             'email cannot be empty',
@@ -228,6 +227,7 @@ describe('i18n module e2e dto', () => {
             'extra.min with value: "1" needs to be at least 5, ow and COOL',
             'extra.max with value: "100" needs to be less than 10, ow and SUPER',
           ],
+          error: 'Bad Request',
         });
       });
 
@@ -243,8 +243,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: [
+          message: [
             'email is ongeldig',
             'e-mail adres mag niet leeg zijn',
             'wachtwoord mag niet leeg zijn',
@@ -252,6 +251,7 @@ describe('i18n module e2e dto', () => {
             'extra.min met waarde: "1" moet hoger zijn dan 5, ow en COOL',
             'extra.max met waarde: "100" moet lager zijn dan 10, ow en SUPER',
           ],
+          error: 'Bad Request',
         });
       });
   });
@@ -359,7 +359,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          errors: [
+          message: [
             {
               property: 'email',
               children: [],
@@ -417,7 +417,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          errors: [
+          message: [
             {
               children: [],
               constraints: {
@@ -481,7 +481,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          errors: [
+          message: [
             {
               property: 'email',
               children: [],
@@ -540,14 +540,14 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 400,
-          message: 'Bad Request',
-          errors: [
+          message: [
             'email is invalid',
             'password cannot be empty',
             'extra.subscribeToEmail is not a boolean',
             'extra.min with value: "1" needs to be at least 5, ow and COOL',
             'extra.max with value: "100" needs to be less than 10, ow and SUPER',
           ],
+          error: 'Bad Request',
         });
       });
   });
@@ -565,8 +565,7 @@ describe('i18n module e2e dto', () => {
       .expect((res) => {
         expect(res.body).toMatchObject({
           statusCode: 422,
-          message: 'Bad Request',
-          errors: [
+          message: [
             'email is invalid',
             'email cannot be empty',
             'password cannot be empty',
@@ -574,6 +573,7 @@ describe('i18n module e2e dto', () => {
             'extra.min with value: "1" needs to be at least 5, ow and COOL',
             'extra.max with value: "100" needs to be less than 10, ow and SUPER',
           ],
+          error: 'Bad Request',
         });
       });
   });

--- a/tests/i18n-express.e2e.spec.ts
+++ b/tests/i18n-express.e2e.spec.ts
@@ -700,8 +700,7 @@ describe('i18n module e2e express', () => {
       .expect(400)
       .expect({
         statusCode: 400,
-        message: 'Bad Request',
-        errors: [
+        message: [
           {
             property: 'age',
             value: 2,
@@ -712,6 +711,7 @@ describe('i18n module e2e express', () => {
             },
           },
         ],
+        error: 'Bad Request',
       });
   });
 

--- a/tests/i18n-fastify.e2e.spec.ts
+++ b/tests/i18n-fastify.e2e.spec.ts
@@ -704,8 +704,7 @@ describe('i18n module e2e fastify', () => {
       .expect(400)
       .expect({
         statusCode: 400,
-        message: 'Bad Request',
-        errors: [
+        message: [
           {
             property: 'age',
             value: 2,
@@ -716,6 +715,7 @@ describe('i18n module e2e fastify', () => {
             },
           },
         ],
+        error: 'Bad Request',
       });
   });
 


### PR DESCRIPTION
Closes Issue no: #646 

This PR addresses issue #646 by modifying the buildResponseBody method in the I18nValidationExceptionFilter class. The goal is to standardize the error response structure for validation errors, ensuring consistency across all exception types in NestJS.
