### PR TITLE
Fix: Typo in Type Safety Guide Documentation

### DIFF
--- a/docs/guides/type-safety.md
+++ b/docs/guides/type-safety.md
@@ -102,7 +102,7 @@ For now type safety is optional and need to be enabled. We're planning to make a
 
 You can also use the generated types in your DTOs. This way you can reduce the chance of having a typo in your validation messages.
 
-```typescript title="src/craete-user.dto.ts"
+```typescript title="src/create-user.dto.ts"
 import { I18nTranslations } from './generated/i18n.generated.ts';
 import {
   IsEmail,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

On the file docs/guides/type-safety.md, I noticed a typo on line 105 where the word "craete" was used instead of "create." I have corrected this typo.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
