### PR TITLE
build: check format & lint in GitHub workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,16 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: 18
           cache: npm
+      - name: install
+        run: npm install
+      - name: check format
+        run: npm run format:check
+      - name: lint
+        run: npm run lint
       - name: test
-        run: |
-          npm install
-          npm run test:cov
+        run: npm run test:cov
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "release": "npm publish --access public",
     "prerelease:next": "npm run build",
     "release:next": "npm publish --access public --tag next",
-    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format": "prettier --write **/*.ts",
+    "format:check": "prettier --check **/*.ts",
     "test": "jest --config ./tests/jest-test.json",
     "test:cov": "jest --config ./tests/jest-test.json --coverage",
     "test:watch": "jest --config ./tests/jest-test.json --watch",
     "coveralls": "npm run test:cov && cat ./coverage/lcov.info | coveralls",
-    "lint": "eslint '{src,apps,libs,test}/**/*.ts'",
-    "lint:fix": "eslint '{src,apps,libs,test}/**/*.ts' --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "docusaurus": "docusaurus",
     "doc:start": "docusaurus start",
     "doc:build": "docusaurus build",
@@ -52,7 +53,8 @@
     "doc:serve": "docusaurus serve",
     "doc:write-translations": "docusaurus write-translations",
     "doc:write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "verify": "npm run format:check && npm run lint && npm run test:cov"
   },
   "devDependencies": {
     "@apollo/client": "^3.6.9",

--- a/src/i18n.context.ts
+++ b/src/i18n.context.ts
@@ -16,7 +16,11 @@ export class I18nContext<K = Record<string, unknown>>
     return this;
   }
 
-  constructor(readonly lang: string, readonly service: I18nService<K>, readonly i18nOptions: I18nOptions,) {}
+  constructor(
+    readonly lang: string,
+    readonly service: I18nService<K>,
+    readonly i18nOptions: I18nOptions,
+  ) {}
 
   public translate<P extends Path<K> = any, R = PathValue<K, P>>(
     key: P,
@@ -64,7 +68,7 @@ export class I18nContext<K = Record<string, unknown>>
     const i18n = this.storage.getStore() as I18nContext<K> | undefined;
 
     if (!i18n && !!context) {
-      return getContextObject(i18n.i18nOptions,context)?.i18nContext;
+      return getContextObject(i18n.i18nOptions, context)?.i18nContext;
     }
 
     return i18n;

--- a/src/interceptors/i18n-language.interceptor.ts
+++ b/src/interceptors/i18n-language.interceptor.ts
@@ -37,7 +37,7 @@ export class I18nLanguageInterceptor implements NestInterceptor {
     const i18nContext = I18nContext.current();
     let language = null;
 
-    const ctx = getContextObject(this.i18nOptions,context);
+    const ctx = getContextObject(this.i18nOptions, context);
 
     // Skip interceptor if language is already resolved (in case of http middleware) or when ctx is undefined (unsupported context)
     if (ctx === undefined || !!ctx.i18nLang) {
@@ -68,7 +68,11 @@ export class I18nLanguageInterceptor implements NestInterceptor {
     }
 
     if (!i18nContext) {
-      ctx.i18nContext = new I18nContext(ctx.i18nLang, this.i18nService, this.i18nOptions);
+      ctx.i18nContext = new I18nContext(
+        ctx.i18nLang,
+        this.i18nService,
+        this.i18nOptions,
+      );
 
       if (!this.i18nOptions.skipAsyncHook) {
         return new Observable((observer) => {

--- a/src/middlewares/i18n.middleware.ts
+++ b/src/middlewares/i18n.middleware.ts
@@ -66,7 +66,11 @@ export class I18nMiddleware implements NestMiddleware {
       req.app.locals.i18nLang = req.i18nLang;
     }
 
-    req.i18nContext = new I18nContext(req.i18nLang, this.i18nService, this.i18nOptions);
+    req.i18nContext = new I18nContext(
+      req.i18nLang,
+      this.i18nService,
+      this.i18nOptions,
+    );
 
     if (this.i18nOptions.skipAsyncHook) {
       next();

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -113,7 +113,6 @@ export class I18nService<K = Record<string, unknown>>
       }" in "${lang}" does not exist.`;
       if (lang !== this.i18nOptions.fallbackLanguage || !!defaultValue) {
         if (this.i18nOptions.logging && this.i18nOptions.throwOnMissingKey) {
-
           this.logger.error(translationKeyMissing);
           throw new I18nError(translationKeyMissing);
         }
@@ -127,7 +126,6 @@ export class I18nService<K = Record<string, unknown>>
           });
         }
       }
-
     }
 
     return (translation ?? key) as unknown as IfAnyOrNever<R, string, R>;

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -19,7 +19,7 @@ export function getContextObject(
     case 'rmq':
       return context.getArgs()[1];
     default:
-      if(i18nOptions.logging){
+      if (i18nOptions.logging) {
         logger.warn(`context type: ${contextType} not supported`);
       }
   }

--- a/tests/app/examples/example.functions.ts
+++ b/tests/app/examples/example.functions.ts
@@ -1,7 +1,6 @@
 import { ArgumentsHost, ValidationError } from '@nestjs/common';
 import { mapChildrenToValidationErrors } from '../../../src/utils/format';
-import {I18nValidationException} from "../../../src";
-
+import { I18nValidationException } from '../../../src';
 
 export const exampleErrorFormatter = (errors: ValidationError[]): object => {
   const errorMessages = {};
@@ -18,12 +17,15 @@ export const exampleErrorFormatter = (errors: ValidationError[]): object => {
   return errorMessages;
 };
 
-
-export const exampleResponseBodyFormatter = (host: ArgumentsHost, exc: I18nValidationException, formattedErrors: object) => {
+export const exampleResponseBodyFormatter = (
+  host: ArgumentsHost,
+  exc: I18nValidationException,
+  formattedErrors: object,
+) => {
   return {
     type: 'static',
     status: exc.getStatus(),
     message: exc.getResponse(),
     data: formattedErrors,
   };
-}
+};

--- a/tests/i18n-dto.e2e.spec.ts
+++ b/tests/i18n-dto.e2e.spec.ts
@@ -256,7 +256,6 @@ describe('i18n module e2e dto', () => {
       });
   });
 
-
   it(`should translate validation messages if a custom response body formatter specified`, async () => {
     await request(app.getHttpServer())
       .post('/hello/validation-custom-response-body-formatter')
@@ -344,7 +343,6 @@ describe('i18n module e2e dto', () => {
         });
       });
   });
-
 
   it(`should translate validation messages with detailed error`, async () => {
     await request(app.getHttpServer())

--- a/tests/i18n-ejs.e2e.spec.ts
+++ b/tests/i18n-ejs.e2e.spec.ts
@@ -23,7 +23,7 @@ import { Global, Module } from '@nestjs/common';
   ],
   exports: ['OPTIONS'],
 })
-export class OptionsModule { }
+export class OptionsModule {}
 
 describe('i18n module e2e ejs', () => {
   let app: NestExpressApplication;

--- a/tests/i18n-express.e2e.spec.ts
+++ b/tests/i18n-express.e2e.spec.ts
@@ -633,7 +633,7 @@ describe('i18n module e2e express', () => {
 
   it(`/GET hello/no-lang-for-service should return translation when providing x-custom-lang`, () => {
     return request(app.getHttpServer())
-    .get('/hello/no-lang-for-service')
+      .get('/hello/no-lang-for-service')
       .set('x-custom-lang', 'nl')
       .expect(200)
       .expect('Hallo');
@@ -671,7 +671,7 @@ describe('i18n module e2e express', () => {
 
   it(`/GET hello/short/no-lang-for-service should return translation when providing x-custom-lang`, () => {
     return request(app.getHttpServer())
-    .get('/hello/short/no-lang-for-service')
+      .get('/hello/short/no-lang-for-service')
       .set('x-custom-lang', 'nl')
       .expect(200)
       .expect('Hallo');

--- a/tests/i18n-fastify.e2e.spec.ts
+++ b/tests/i18n-fastify.e2e.spec.ts
@@ -637,7 +637,7 @@ describe('i18n module e2e fastify', () => {
 
   it(`/GET hello/no-lang-for-service should return translation when providing x-custom-lang`, () => {
     return request(app.getHttpServer())
-    .get('/hello/no-lang-for-service')
+      .get('/hello/no-lang-for-service')
       .set('x-custom-lang', 'nl')
       .expect(200)
       .expect('Hallo');
@@ -675,7 +675,7 @@ describe('i18n module e2e fastify', () => {
 
   it(`/GET hello/short/no-lang-for-service should return translation when providing x-custom-lang`, () => {
     return request(app.getHttpServer())
-    .get('/hello/short/no-lang-for-service')
+      .get('/hello/short/no-lang-for-service')
       .set('x-custom-lang', 'nl')
       .expect(200)
       .expect('Hallo');
@@ -696,7 +696,7 @@ describe('i18n module e2e fastify', () => {
       .expect(200)
       .expect('Hallo');
   });
-  
+
   it('/POST cats with age 2 should error', async () => {
     await request(app.getHttpServer())
       .post('/cats')


### PR DESCRIPTION
### Description

While preparing another change, I noticed that the `lint` script doesn't work and that there formatting issues in the code.
Both could be detected if the GitHub workflow `test` would also lint & check the formatting.
This is added by this PR.

I also added a `verify` script to be able to easily execute all relevant scripts locally.

To get the build green, we also need to format the code in this PR. I'd suggest to extract these formatting changes into another PR which should be merged before this one (#670).

### Additional context

The current `lint` script `eslint '{src,apps,libs,test}/**/*.ts'` runs into the following error:
```
> eslint '{src,apps,libs,test}/**/*.ts'

Oops! Something went wrong! :(

ESLint: 8.49.0

No files matching the pattern "'{src,apps,libs,test}/**/*.ts'" were found.
Please check for typing mistakes in the pattern.
```
