### PR TITLE
fix: remove i18nOptions from I18nContext class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-i18n",
-  "version": "10.4.7",
+  "version": "10.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-i18n",
-      "version": "10.4.7",
+      "version": "10.4.9",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",

--- a/src/i18n.context.ts
+++ b/src/i18n.context.ts
@@ -1,6 +1,6 @@
 import { ArgumentsHost } from '@nestjs/common';
 import { AsyncLocalStorage } from 'async_hooks';
-import { I18nOptions, I18nTranslator, I18nValidationError } from './interfaces';
+import { I18nTranslator, I18nValidationError } from './interfaces';
 import { I18nService, TranslateOptions } from './services/i18n.service';
 import { Path, PathValue } from './types';
 import { getContextObject } from './utils';
@@ -19,7 +19,6 @@ export class I18nContext<K = Record<string, unknown>>
   constructor(
     readonly lang: string,
     readonly service: I18nService<K>,
-    readonly i18nOptions: I18nOptions,
   ) {}
 
   public translate<P extends Path<K> = any, R = PathValue<K, P>>(
@@ -68,7 +67,7 @@ export class I18nContext<K = Record<string, unknown>>
     const i18n = this.storage.getStore() as I18nContext<K> | undefined;
 
     if (!i18n && !!context) {
-      return getContextObject(i18n.i18nOptions, context)?.i18nContext;
+      return getContextObject(undefined, context)?.i18nContext;
     }
 
     return i18n;

--- a/src/interceptors/i18n-language.interceptor.ts
+++ b/src/interceptors/i18n-language.interceptor.ts
@@ -68,11 +68,7 @@ export class I18nLanguageInterceptor implements NestInterceptor {
     }
 
     if (!i18nContext) {
-      ctx.i18nContext = new I18nContext(
-        ctx.i18nLang,
-        this.i18nService,
-        this.i18nOptions,
-      );
+      ctx.i18nContext = new I18nContext(ctx.i18nLang, this.i18nService);
 
       if (!this.i18nOptions.skipAsyncHook) {
         return new Observable((observer) => {

--- a/src/middlewares/i18n.middleware.ts
+++ b/src/middlewares/i18n.middleware.ts
@@ -66,11 +66,7 @@ export class I18nMiddleware implements NestMiddleware {
       req.app.locals.i18nLang = req.i18nLang;
     }
 
-    req.i18nContext = new I18nContext(
-      req.i18nLang,
-      this.i18nService,
-      this.i18nOptions,
-    );
+    req.i18nContext = new I18nContext(req.i18nLang, this.i18nService);
 
     if (this.i18nOptions.skipAsyncHook) {
       next();

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -4,7 +4,7 @@ import { I18nOptions } from '..';
 const logger = new Logger('I18nService');
 
 export function getContextObject(
-  i18nOptions: I18nOptions,
+  i18nOptions?: I18nOptions,
   context?: ExecutionContext | ArgumentsHost,
 ): any {
   const contextType = context?.getType<string>() ?? 'undefined';
@@ -19,7 +19,7 @@ export function getContextObject(
     case 'rmq':
       return context.getArgs()[1];
     default:
-      if (i18nOptions.logging) {
+      if (i18nOptions?.logging) {
         logger.warn(`context type: ${contextType} not supported`);
       }
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The root cause stems from this pull request:
https://github.com/toonvanstrijp/nestjs-i18n/pull/653

We cannot access the i18nOptions passed from the constructor within the static function I18nContext.current. And when an error occurs in any middleware, the I18nContext will not be initialized, causing [this.storage.getStore()](https://github.com/toonvanstrijp/nestjs-i18n/blob/d852410b5cd25388694c2a599ddbbb051e3101d1/src/i18n.context.ts#L67) to return undefined.

Steps to reproduce this issue:

I use i18n in a GlobalExceptionFilter class:

```
@Catch()
export class GlobalExceptionFilter implements ExceptionFilter {
private i18n: I18nContext<I18nTranslations>;
catch(exception: any, host: ArgumentsHost): void {
    const { httpAdapter } = this.httpAdapterHost;
    const ctx = host.switchToHttp();
    this.i18n = I18nContext.current<I18nTranslations>(host);
    ...
}
```

Trigger an error in a different middleware:

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/adcc1135-36f4-4436-95cc-b958ac99263f">

The error occurs here: I18nContext.current<I18nTranslations>(host);

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/fb02fd90-c17d-40db-b858-bb47e5211956">


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
