### PR TITLE
fix: fixed minor bug with utils/file exists() function

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,9 +1,15 @@
-import { readdir, lstat, stat } from 'fs/promises';
+import { readdir, lstat, access } from 'fs/promises';
 import type { Dirent } from 'fs';
 import * as path from 'path';
 
 export const exists = async (path: string): Promise<boolean> => {
-  return !!(await stat(path));
+  try {
+    await access(path);
+
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 export function mapAsync<T, U>(

--- a/tests/utils/file.spec.ts
+++ b/tests/utils/file.spec.ts
@@ -1,0 +1,15 @@
+import { join } from 'node:path';
+
+import { exists } from '../../src/utils/file';
+
+describe('file util tests', () => {
+    describe('exists() tests', () => {
+        it('should return true if the file exists', async () => {
+            await expect(exists(join(__dirname, 'test-file.txt'))).resolves.toBe(true);
+        });
+
+        it('should return false if the file does not exist', async () => {
+            await expect(exists(join(__dirname, 'not-test-file.txt'))).resolves.toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

While investigating an issue I had with the JSON loader, I found that the exists function does not work as intended. The `node:fs/promises` `stat()` function resolves with the stats data if the file exists, but the promise is rejected when the file does not exist, so the function never really returns `false`, swallowing the errors for `getFiles` in the `parseTranslations()` function as well as the `new I18nError` at the top of `parseTranslations()` after the `exists()` check.

I also came across this line
> Using `fs.stat()` to check for the existence of a file before calling `fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended. Instead, user code should open/read/write the file directly and handle the error raised if the file is not available. To check if a file exists without manipulating it afterwards, [`fs.access()`](https://nodejs.org/api/fs.html#fsaccesspath-mode-callback) is recommended.
In the Node.JS docs here: https://nodejs.org/api/fs.html#fsstatpath-options-callback

So I also switched the implementation to use `fs.access` instead of `fs.stat`.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
