### PR TITLE
Migrate to Express v5 routes

### DIFF
--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -152,7 +152,7 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
     consumer
       .apply(I18nMiddleware)
       .forRoutes(
-        isNestMiddleware(consumer) && usingFastify(consumer) ? '(.*)' : '*',
+        isNestMiddleware(consumer) && usingFastify(consumer) ? '(.*path)' : '*path',
       );
   }
 


### PR DESCRIPTION
add names to wildcards for middlewares

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In Express 5, wildcards must have names; i18n.module had middleware registeration for all routes, so a name must be used after the "*" character.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
