### PR TITLE
bugfix: exclude array key names only for array fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-i18n",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-i18n",
-      "version": "10.5.0",
+      "version": "10.5.1",
       "license": "MIT",
       "dependencies": {
         "accept-language-parser": "^1.5.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,14 +11,20 @@ type IsAny<T> = unknown extends T
     : true
   : false;
 
+type IsArray<T> = T extends any[] ? true : false
+
+type ExcludeArrayKeys<T> =
+  IsArray<T> extends true
+    ? Exclude<keyof T, keyof any[]>
+    : keyof T
+
 type PathImpl<T, Key extends keyof T> = Key extends string
   ? IsAny<T[Key]> extends true
     ? never
     : T[Key] extends Record<string, any>
     ?
-        | `${Key}.${PathImpl<T[Key], Exclude<keyof T[Key], keyof any[]>> &
-            string}`
-        | `${Key}.${Exclude<keyof T[Key], keyof any[]> & string}`
+        | `${Key}.${PathImpl<T[Key], ExcludeArrayKeys<T[Key]>> & string}`
+        | `${Key}.${ExcludeArrayKeys<T[Key]> & string}`
     : never
   : never;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,12 +11,11 @@ type IsAny<T> = unknown extends T
     : true
   : false;
 
-type IsArray<T> = T extends any[] ? true : false
+type IsArray<T> = T extends any[] ? true : false;
 
-type ExcludeArrayKeys<T> =
-  IsArray<T> extends true
-    ? Exclude<keyof T, keyof any[]>
-    : keyof T
+type ExcludeArrayKeys<T> = IsArray<T> extends true
+  ? Exclude<keyof T, keyof any[]>
+  : keyof T;
 
 type PathImpl<T, Key extends keyof T> = Key extends string
   ? IsAny<T[Key]> extends true


### PR DESCRIPTION
### Description

When a key name exists with the same name as an array method / field, that key will not be available as the generated type.

Example generated file:
```typescript
export type I18nTranslations = {
    "common": {
        "shift": {
            "created": string;
        };
    };
};
export type I18nPath = Path<I18nTranslations>;
```

The type does not recognise the key `common.shift.created`.

I fixed the type by excluding array key names only when the field contains an array.

### Linked Issues
/

### Additional context
/

