### PR TITLE
fix: add ConfigModule import to I18nModule setup

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -126,6 +126,7 @@ import { I18nModule, AcceptLanguageResolver, QueryResolver, HeaderResolver } fro
 @Module({
   imports: [
     I18nModule.forRootAsync({
+      imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
         fallbackLanguage: configService.getOrThrow('FALLBACK_LANGUAGE'),
         loaderOptions: {


### PR DESCRIPTION
### Description

Just fix the documentation because imports config module is missing forRootAsync configuration.

### Linked Issues


### Additional context


