### PR TITLE
fix: create type import when generating types (#698)

### DIFF
--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -66,7 +66,7 @@ export const createTypesFile = async (object: any) => {
     ts.factory.createImportDeclaration(
       undefined,
       ts.factory.createImportClause(
-        false,
+        true,
         undefined,
         ts.factory.createNamedImports([
           ts.factory.createImportSpecifier(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When generating translation types file, use `import type` instead of `import` to prevent compiler errors when `importsNotUsedAsValues` or `verbatimModuleSyntax` flags are enabled.

### Linked Issues
#698 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
