### PR TITLE
Security: Prototype Pollution in mergeDeep Utility

### DIFF
--- a/src/utils/merge.ts
+++ b/src/utils/merge.ts
@@ -10,6 +10,7 @@ export function mergeDeep(target: I18nTranslation, ...sources: any) {
 
   if (isObject(target) && isObject(source)) {
     for (const key in source) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
       if (isObject(source[key])) {
         if (!target[key]) Object.assign(target, { [key]: {} });
         mergeDeep(target[key] as I18nTranslation, source[key]);


### PR DESCRIPTION
## Summary

Security: Prototype Pollution in mergeDeep Utility

## Problem

**Severity**: `High` | **File**: `src/utils/merge.ts:L7`

The `mergeDeep` function in `src/utils/merge.ts` recursively merges objects without validating keys against prototype pollution vectors (`__proto__`, `constructor`, `prototype`). An attacker who can control translation file content or merged objects could modify Object.prototype, leading to application-wide denial of service or potential remote code execution in vulnerable Node.js environments.

## Solution

Add key validation to reject `__proto__`, `constructor`, and `prototype` keys before assignment, or use `Object.create(null)` for target objects to prevent prototype chain pollution. Example: `if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;`

## Changes

- `src/utils/merge.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced