### PR TITLE
fix: resolve #487 — [HELP] Maintainers wanted!

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,3 +5,6 @@ contact_links:
   - name: ⁉️ Why and How to make a reproduction?
     url: https://antfu.me/posts/why-reproductions-are-required
     about: Reproduction is very important for maintainer to help on your issues!
+  - name: 🙋 Maintainer Search
+    url: https://github.com/toonvanstrijp/nestjs-i18n/issues/487
+    about: Interested in helping maintain this project? Check out Issue #487!

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,85 @@
+# Maintainers
+
+This document outlines the governance structure for the nestjs-i18n project, including current maintainers, their responsibilities, and the process for becoming a maintainer.
+
+## Current Maintainers
+
+| Name | GitHub | Role | Since |
+|------|--------|------|-------|
+| Toon van Strijp | [@toonvanstrijp](https://github.com/toonvanstrijp) | Lead Maintainer | 2019 |
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for:
+
+- **Code Review**: Reviewing and merging pull requests in a timely manner
+- **Issue Triage**: Responding to bug reports, feature requests, and questions
+- **Release Management**: Preparing and publishing new versions to npm
+- **Documentation**: Keeping README, API docs, and examples up to date
+- **Community**: Fostering a welcoming and inclusive environment
+- **Technical Direction**: Guiding the project's architecture and feature roadmap
+
+## Time Commitment
+
+Maintainers are expected to dedicate approximately 2-4 hours per week to the project. This includes:
+
+- Reviewing open PRs and issues
+- Responding to mentions and discussions
+- Participating in architectural decisions
+
+There are no strict requirements—maintainers may take breaks as needed. Inactive maintainers may be moved to emeritus status after 6 months of inactivity.
+
+## Required Skills
+
+Potential maintainers should have:
+
+- Strong TypeScript and Node.js experience
+- Familiarity with NestJS framework patterns
+- Understanding of internationalization (i18n) concepts
+- Experience with Git and GitHub workflows
+- Good communication skills in English
+- Commitment to code quality and testing
+
+## Decision Making
+
+We use a lazy consensus model:
+
+- Minor changes (bug fixes, documentation updates) can be merged by any maintainer
+- Significant changes (new features, breaking changes) require approval from at least one other maintainer
+- Major architectural decisions are discussed in GitHub issues before implementation
+
+If consensus cannot be reached, the lead maintainer has the final decision.
+
+## Becoming a Maintainer
+
+To become a maintainer:
+
+1. **Contribute**: Make meaningful contributions over time (typically 3+ months)
+2. **Demonstrate**: Show good judgment, code quality, and community interaction
+3. **Express Interest**: Open an issue or contact existing maintainers
+4. **Nomination**: An existing maintainer nominates you
+5. **Approval**: Current maintainers approve by consensus
+
+New maintainers are granted:
+
+- Write access to the repository
+- npm publish permissions
+- Ability to manage issues and PRs
+
+## Emeritus Maintainers
+
+Former maintainers who have stepped down:
+
+*None yet*
+
+Emeritus maintainers retain recognition for their contributions and may return to active status by request.
+
+## Contact
+
+- **Security Issues**: Email maintainers directly or use GitHub Security Advisories
+- **General Questions**: Open a GitHub Discussion
+- **Private Matters**: Contact [@toonvanstrijp](https://github.com/toonvanstrijp)
+
+---
+
+*Last updated: 2024*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
   </p>
 </p>
 
+## ⚠️ Maintainers Wanted
+
+This project is actively seeking co-maintainers. The current maintainer has limited time to dedicate to issue triage, PR reviews, and ongoing feature development. If you're interested in helping maintain this popular NestJS i18n library, please open an issue or discussion to express your interest. Any help with triaging issues, reviewing pull requests, or contributing features would be greatly appreciated!
+
 ## Features
 
 **nestjs-i18n** comes with a bunch of tools to help add multiple language support to your project.


### PR DESCRIPTION
## Summary

fix: resolve #487 — [HELP] Maintainers wanted!

## Problem

**Severity**: `High` | **File**: `README.md`

Add a highly visible notice at the top of the README indicating that the project is actively seeking co-maintainers. This should include a brief explanation of the current situation, what kind of help is needed (issue triage, PR reviews, feature development), and how interested contributors can get in touch or express interest. This is critical for visibility to find new maintainers.

## Solution

Add a prominent banner or section immediately after the title/description, such as:

## Changes

- `README.md` (modified)
- `MAINTAINERS.md` (new)
- `.github/ISSUE_TEMPLATE/config.yml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced