### PR TITLE
fix: resolve #475 — Suggestion to implement ICU syntax for gender and pluralization

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/hbs": "^4.0.5",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/messageformat": "^2.0.0",
     "@types/node": "^25.6.0",
     "@types/string-format": "^2.0.3",
     "@types/supertest": "^7.2.0",
@@ -113,6 +114,7 @@
     "cookie": "^1.1.1",
     "iterare": "^1.2.1",
     "js-yaml": "^4.1.1",
+    "messageformat": "^2.3.0",
     "string-format": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/i18n.context.ts
+++ b/src/i18n.context.ts
@@ -3,7 +3,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { I18nTranslator, I18nValidationError } from './interfaces';
 import { I18nService, TranslateOptions } from './services/i18n.service';
 import { Path, PathValue } from './types';
-import { getContextObject } from './utils';
+import { getContextObject, I18nMessageFormat } from './utils';
 
 export class I18nContext<K = Record<string, unknown>> implements I18nTranslator<K> {
   private static storage = new AsyncLocalStorage<I18nContext>();
@@ -17,6 +17,7 @@ export class I18nContext<K = Record<string, unknown>> implements I18nTranslator<
   constructor(
     readonly lang: string,
     readonly service: I18nService<K>,
+    readonly messageFormat: I18nMessageFormat,
   ) {}
 
   public translate<P extends Path<K> = any, R = PathValue<K, P>>(
@@ -27,7 +28,21 @@ export class I18nContext<K = Record<string, unknown>> implements I18nTranslator<
       lang: this.lang,
       ...options,
     };
-    return this.service.translate<P, R>(key, options);
+    const result = this.service.translate<P, R>(key, options);
+
+    if (options.useICU && typeof result === 'string') {
+      try {
+        const compiled = this.messageFormat.compile(result, options.lang);
+        const formatted = compiled(options.args);
+        if (formatted !== undefined) {
+          return formatted as R;
+        }
+      } catch {
+        // Fall back to original result
+      }
+    }
+
+    return result;
   }
 
   public t<P extends Path<K> = any, R = PathValue<K, P>>(key: P, options?: TranslateOptions) {

--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -38,6 +38,7 @@ import { I18nMiddleware } from './middlewares/i18n.middleware';
 import * as fs from 'fs';
 import * as path from 'path';
 import { NestMiddlewareConsumer } from './types';
+import { I18nMessageFormat } from './utils/i18n-messageformat';
 export const logger = new Logger('I18nService');
 
 const defaultOptions: Partial<I18nOptions> = {
@@ -181,10 +182,16 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
       useValue: options,
     };
 
-    const i18nLoaderProvider: ClassProvider = {
-      provide: I18nLoader,
-      useClass: options.loader!,
-    };
+const i18nLoaderProvider: ClassProvider = {
+  provide: I18nLoader,
+  useClass: options.loader!,
+};
+
+const i18nMessageFormatProvider: Provider = {
+  provide: I18nMessageFormat,
+  useFactory: (options: I18nOptions) => new I18nMessageFormat(options),
+  inject: [I18N_OPTIONS],
+};
 
     const i18nLoaderOptionsProvider: ValueProvider = {
       provide: I18N_LOADER_OPTIONS,
@@ -258,6 +265,7 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
         resolversProvider,
         i18nLoaderProvider,
         i18nLoaderOptionsProvider,
+    i18nMessageFormatProvider,
         i18nLanguagesSubjectProvider,
         i18nTranslationSubjectProvider,
         ...this.createResolverProviders(options.resolvers),

--- a/src/interfaces/i18n-options.interface.ts
+++ b/src/interfaces/i18n-options.interface.ts
@@ -54,6 +54,13 @@ export interface I18nOptions {
   validatorOptions?: I18nValidatorOptions;
   throwOnMissingKey?: boolean;
   typesOutputPath?: string;
+  useICU?: boolean;
+  icuOptions?: {
+    biDiSupport?: boolean;
+    formatters?: Record<string, Function>;
+    strictNumberSign?: boolean;
+  };
+  icuLocales?: string[];
 }
 
 export interface I18nOptionsFactory {

--- a/src/utils/message-format.util.ts
+++ b/src/utils/message-format.util.ts
@@ -1,0 +1,38 @@
+import { MessageFormat } from 'messageformat';
+
+export class I18nMessageFormat {
+  private readonly messageFormats = new Map<string, MessageFormat>();
+
+  compile(message: string, locale: string): (params?: Record<string, any>) => string {
+    try {
+      let messageFormat = this.messageFormats.get(locale);
+      if (!messageFormat) {
+        messageFormat = new MessageFormat(locale);
+        this.messageFormats.set(locale, messageFormat);
+      }
+      return messageFormat.compile(message);
+    } catch {
+      return () => message;
+    }
+  }
+
+  compileObject(
+    translations: Record<string, any>,
+    locale: string,
+  ): Record<string, any> {
+    const result: Record<string, any> = {};
+
+    for (const key of Object.keys(translations)) {
+      const value = translations[key];
+      if (typeof value === 'string') {
+        result[key] = this.compile(value, locale);
+      } else if (typeof value === 'object' && value !== null) {
+        result[key] = this.compileObject(value, locale);
+      } else {
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

fix: resolve #475 — Suggestion to implement ICU syntax for gender and pluralization

## Problem

**Severity**: `High` | **File**: `package.json`

Add the messageformat library (messageformat.js) as a core dependency to enable ICU MessageFormat syntax parsing for pluralization, gender selection, and other ICU features. This is required for the new ICU functionality to work.

## Solution

Add "messageformat": "^2.3.0" to the dependencies section. Also add "@types/messageformat": "^2.0.0" to devDependencies for TypeScript support. This library will power the ICU syntax parsing capabilities.

## Changes

- `package.json` (modified)
- `src/utils/message-format.util.ts` (new)
- `src/interfaces/i18n-options.interface.ts` (modified)
- `src/i18n.context.ts` (modified)
- `src/i18n.module.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced