### PR TITLE
fix: use named wildcard ({*path}) for Fastify i18n middleware route

### DIFF
--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -177,7 +177,7 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
   configure(consumer: NestMiddlewareConsumer) {
     if (this.i18nOptions.disableMiddleware) return;
 
-    const middlewareRoute = usingFastify(consumer) ? '*' : '*path';
+    const middlewareRoute = usingFastify(consumer) ? '{*path}' : '*path';
     consumer.apply(I18nMiddleware).forRoutes(middlewareRoute);
 
     if (usingFastify(consumer)) {


### PR DESCRIPTION
### What & why

When using the **Fastify** adapter together with `app.setGlobalPrefix(...)`, every app that imports `I18nModule` logs this on boot:

```
WARN [LegacyRouteConverter] Unsupported route path: "/<prefix>/*". ... Attempting to auto-convert...
```

The middleware is registered here:

```ts
// src/i18n.module.ts
const middlewareRoute = usingFastify(consumer) ? '*' : '*path';
consumer.apply(I18nMiddleware).forRoutes(middlewareRoute);
```

The Express branch already uses a named wildcard (`*path`), but that exact token throws `TypeError: Unexpected MODIFIER at N, expected END` under `@fastify/middie`'s `path-to-regexp` (see #710), which is why the Fastify branch was reverted to the bare `*`. The bare `*` is a legacy wildcard under Express 5 / path-to-regexp v8, so once a global prefix turns it into `/<prefix>/*`, Nest's `LegacyRouteConverter` warns (and auto-converts) on every startup. Reported in #694 and #710.

### The fix

Use the **named-group wildcard** `{*path}` for the Fastify branch:

```ts
const middlewareRoute = usingFastify(consumer) ? '{*path}' : '*path';
```

`{*path}` is:
- **accepted by `@fastify/middie`** (no `TypeError`, unlike `*path`),
- a **match-all** that also matches the root `/` (same coverage as the old `*`),
- exactly what Nest's own `LegacyRouteConverter` auto-converts `*` into — so it's the canonical replacement.

This removes the warning **and** avoids the #710 `TypeError`, with no behavior change. The Express branch is untouched.

### Verification

- End-to-end check under Fastify + `setGlobalPrefix('v1')`: app boots with **no warning** and **no throw**, an actual request hits the route (`200`), and the i18n middleware **runs on the request**.
- Test suites pass locally (Fastify + view engines + Express + disable-middleware + middleware):
  - `i18n-fastify.e2e` — 75 passed
  - `i18n-fastify-eta / -pug / -nunjucks / -ejs`, `i18n-express.e2e`, `i18n-disable-middleware.e2e`, `i18n-middleware` — 88 passed
- `oxfmt --check` and `oxlint` clean on the changed file.

### Notes

One-line change. No new dependencies, no API change.
