### PR TITLE
fix: forRootAsync manual onModuleDestory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-i18n",
-  "version": "10.8.4",
+  "version": "10.8.5",
   "description": "The i18n module for Nest.",
   "keywords": [
     "i18n",

--- a/src/i18n.module.ts
+++ b/src/i18n.module.ts
@@ -72,6 +72,7 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
     @Inject(I18N_TRANSLATIONS)
     private translations: Observable<I18nTranslation>,
     @Inject(I18N_OPTIONS) private readonly i18nOptions: I18nOptions,
+    @Inject(I18N_LOADERS) private readonly loaders: I18nLoader[],
     private adapter: HttpAdapterHost,
     private readonly middleware: I18nMiddleware,
   ) {}
@@ -169,9 +170,15 @@ export class I18nModule implements OnModuleInit, OnModuleDestroy, NestModule {
     }
   }
 
-  onModuleDestroy() {
+  async onModuleDestroy() {
     this.unsubscribe.next();
     this.unsubscribe.complete();
+
+    // Loaders created inside the forRootAsync factory (or passed
+    // pre-instantiated via the `loaders` option) are not managed by Nest's DI
+    // lifecycle, so their own onModuleDestroy is never invoked. Close them
+    // here.
+    await Promise.all(this.loaders.map((loader) => loader.onModuleDestroy?.()));
   }
 
   configure(consumer: NestMiddlewareConsumer) {

--- a/src/loaders/i18n.loader.ts
+++ b/src/loaders/i18n.loader.ts
@@ -4,4 +4,5 @@ import { Observable } from 'rxjs';
 export abstract class I18nLoader {
   abstract languages(): Promise<string[] | Observable<string[]>>;
   abstract load(): Promise<I18nTranslation | Observable<I18nTranslation>>;
+  onModuleDestroy?(): Promise<void> | void;
 }

--- a/tests/i18n-module.spec.ts
+++ b/tests/i18n-module.spec.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
+
+import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+
+import { I18N_LOADERS } from '../src/i18n.constants';
 import { I18nModule } from '../src/i18n.module';
 import { logger } from '../src/utils';
-import { I18N_LOADERS } from '../src/i18n.constants';
-import { INestApplication } from '@nestjs/common';
 
 describe('i18n module', () => {
   afterEach(() => {

--- a/tests/i18n-module.spec.ts
+++ b/tests/i18n-module.spec.ts
@@ -1,5 +1,9 @@
+import path from 'node:path';
+import { Test, TestingModule } from '@nestjs/testing';
 import { I18nModule } from '../src/i18n.module';
 import { logger } from '../src/utils';
+import { I18N_LOADERS } from '../src/i18n.constants';
+import { INestApplication } from '@nestjs/common';
 
 describe('i18n module', () => {
   afterEach(() => {
@@ -59,16 +63,91 @@ describe('i18n module', () => {
     expect(getInstance).not.toHaveBeenCalled();
   });
 
-  it('emits unsubscribe notifier on module destroy', () => {
+  it('emits unsubscribe notifier on module destroy', async () => {
     const module = Object.create(I18nModule.prototype) as any;
     module.unsubscribe = {
       next: jest.fn(),
       complete: jest.fn(),
     };
+    module.loaders = [];
 
-    module.onModuleDestroy();
+    await module.onModuleDestroy();
 
     expect(module.unsubscribe.next).toHaveBeenCalledTimes(1);
     expect(module.unsubscribe.complete).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when initialized with forRoot', () => {
+    let app: INestApplication;
+    let loader: any;
+
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [
+          I18nModule.forRoot({
+            fallbackLanguage: 'en',
+            loaderOptions: { path: path.join(__dirname, 'i18n'), watch: true },
+          }),
+        ],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+
+      loader = app.get(I18N_LOADERS)[0];
+    });
+
+    afterEach(async () => {
+      // Manually call onModuleDestroy to avoid Jest open handle error.
+      loader.onModuleDestroy();
+    });
+
+    it('closes loaders on application close', async () => {
+      const spy = jest.spyOn(loader, 'onModuleDestroy');
+
+      await app.close();
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('when initialized with forRootAsync', () => {
+    let app: INestApplication;
+    let loader: any;
+
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [
+          I18nModule.forRootAsync({
+            useFactory: () => ({
+              fallbackLanguage: 'en',
+              loaderOptions: {
+                path: path.join(__dirname, 'i18n'),
+                watch: true,
+              },
+            }),
+            resolvers: [],
+          }),
+        ],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+
+      loader = app.get(I18N_LOADERS)[0];
+    });
+
+    afterEach(async () => {
+      // Manually call onModuleDestroy to avoid Jest open handle error.
+      loader.onModuleDestroy();
+    });
+
+    it('closes loaders on application close', async () => {
+      const spy = jest.spyOn(loader, 'onModuleDestroy');
+
+      await app.close();
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### Description

Loaders created inside the `forRootAsync` factory, or passed pre-instantiated via the `loaders` option, are not managed by Nest's DI lifecycle, so their `onModuleDestroy` hook was never invoked. An active file watcher (`loaderOptions.watch: true`) would then keep the event loop alive and prevent the process from exiting after `app.close()`. I noticed that because my CLI commands would never close in my project since I activated watch for local development.

What I did:

- Declare an optional `onModuleDestroy` cleanup hook on the `I18nLoader` base class,
- Await each loader's cleanup from `I18nModule.onModuleDestroy`,
- Add tests for both `forRoot` and `forRootAsync`.

### Linked Issues

No existing issue.

### Additional context

Nothing 
